### PR TITLE
Add a few routes for FR-IDF

### DIFF
--- a/FR-IDF-aerial/FR-IDF-aerial-Routes.txt
+++ b/FR-IDF-aerial/FR-IDF-aerial-Routes.txt
@@ -1,0 +1,63 @@
+
+#
+# This data is *not* stored in the OSM Wiki but in GitHub 
+#
+# Format: format is like in the OSM Wiki
+#
+# Links: [[...|...]] are interne link like in the OSM Wiki
+#        [... ...] are external links
+#
+# Headers start with '=', '==', '===', '====', ... at the beginning of a line
+#
+# Simple text starts with '-' at the beginning of a line.
+#    A single '-' at the beginning of a line, followed by nothing:
+#    - if there was simple text before, it creates a line feed (i.e. encloses the text in a paragraph <p> ... </p>)
+#    - if there was no simple text before or a line feed, it creates an empty line (i.e. <p>&amp;nbsp;</p>)
+#
+# !!!Text yellow background!!! in simple text or headers
+# '''''Text mit bold and italics''''' in simple text or headers
+# '''Text with bold chars''' in simple text or headers
+# ''Text with italic chars'' in simple text or headers
+#
+# Comments start with '#' at the beginning of a line. '#' inside text is not recognized as the start of a comment, i.e.. '#' may occur inside of text.
+#
+# Format of the file: UTF-8
+#
+#
+# Contents in CSV-Format - if ';' is part of the field, then enclose that field in "..."
+#
+# ref;type;comment;from;to;operator
+#
+# - ref       == tag 'ref' of route or route_master
+#                250            defines that routes with 'ref'='250' are expected
+#                250|250a|250b  defines that routes with 'ref'='250' or 'ref'='250a' or 'ref'='250b' are expected - independent of whether this is allowed according to PTv1/PTv2
+# - type      == contents of tags 'route' respectively 'route_master'
+# - comment   == can include comments like; Bus, Expressbus, ...  will not be analyzed, but simply be printed out
+#                !Text with yellow background! in comment (surrounded by single !)
+# - from      == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - to        == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - operator  == if there is more than one entry with "ref;type", then "operator" is used to distinguish between same line number in different cities/villages
+#
+
+
+= Overview on '''Aérial''' Public Transport Lines
+
+-
+- '''!!!This summary is a list of what has been published in open data by Île-de-France Mobilités and found in OSM!!!'''
+-
+- Feel free to modify the list on github
+-
+#
+#ref;type;comment;from;to;operator
+
+== Lines
+1;bus;;;;
+111;bus;;;;
+112;bus;;;;
+2;bus;;;;
+3;bus;;;;
+4;bus;;;;
+4.;bus;;;;
+5;bus;;;;
+6;bus;;;;
+8;bus;;;;

--- a/FR-IDF-aerial/settings.sh
+++ b/FR-IDF-aerial/settings.sh
@@ -1,0 +1,31 @@
+
+#!/bin/bash
+
+#
+# set variales for analysis of network
+#
+
+PREFIX="FR-IDF-aerial"
+
+OVERPASS_QUERY="http://overpass-api.de/api/interpreter?data=area[wikidata=Q13917][type=boundary];(rel(area)[route~'bus'];rel(br);rel[type='route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r.routes);node(r.routes););out;"
+NETWORK_LONG=""
+NETWORK_SHORT="Aérial"
+
+ANALYSIS_PAGE=""
+ANALYSIS_TALK=""
+#
+# Routes data is in GitHub only, not in OSM-Wiki
+#
+WIKI_ROUTES_PAGE=""
+
+ANALYSIS_OPTIONS="--check-access --check-bus-stop --check-name --check-osm-separator --check-sequence --check-stop-position --check-version --coloured-sketchline --check-motorway-link --max-error=10 --multiple-ref-type-entries=analyze --positive-notes"
+
+# --language=en
+# --check-bus-stop 
+# --expect-network-short
+# --expect-network-long
+# --expect-network-short-for=
+# --expect-network-long-for=
+# --relaxed-begin-end-for=
+
+    

--- a/FR-IDF-albatrans/FR-IDF-albatrans-Routes.txt
+++ b/FR-IDF-albatrans/FR-IDF-albatrans-Routes.txt
@@ -1,0 +1,64 @@
+
+#
+# This data is *not* stored in the OSM Wiki but in GitHub 
+#
+# Format: format is like in the OSM Wiki
+#
+# Links: [[...|...]] are interne link like in the OSM Wiki
+#        [... ...] are external links
+#
+# Headers start with '=', '==', '===', '====', ... at the beginning of a line
+#
+# Simple text starts with '-' at the beginning of a line.
+#    A single '-' at the beginning of a line, followed by nothing:
+#    - if there was simple text before, it creates a line feed (i.e. encloses the text in a paragraph <p> ... </p>)
+#    - if there was no simple text before or a line feed, it creates an empty line (i.e. <p>&amp;nbsp;</p>)
+#
+# !!!Text yellow background!!! in simple text or headers
+# '''''Text mit bold and italics''''' in simple text or headers
+# '''Text with bold chars''' in simple text or headers
+# ''Text with italic chars'' in simple text or headers
+#
+# Comments start with '#' at the beginning of a line. '#' inside text is not recognized as the start of a comment, i.e.. '#' may occur inside of text.
+#
+# Format of the file: UTF-8
+#
+#
+# Contents in CSV-Format - if ';' is part of the field, then enclose that field in "..."
+#
+# ref;type;comment;from;to;operator
+#
+# - ref       == tag 'ref' of route or route_master
+#                250            defines that routes with 'ref'='250' are expected
+#                250|250a|250b  defines that routes with 'ref'='250' or 'ref'='250a' or 'ref'='250b' are expected - independent of whether this is allowed according to PTv1/PTv2
+# - type      == contents of tags 'route' respectively 'route_master'
+# - comment   == can include comments like; Bus, Expressbus, ...  will not be analyzed, but simply be printed out
+#                !Text with yellow background! in comment (surrounded by single !)
+# - from      == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - to        == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - operator  == if there is more than one entry with "ref;type", then "operator" is used to distinguish between same line number in different cities/villages
+#
+
+
+= Overview on '''Albatrans''' Public Transport Lines
+
+-
+- '''!!!This summary is a list of what has been published in open data by Île-de-France Mobilités and found in OSM!!!'''
+-
+- Feel free to modify the list on github
+-
+#
+#ref;type;comment;from;to;operator
+
+== Lines
+91-01;bus;;;;
+91-02;bus;;;;
+91-03;bus;;;;
+91-04;bus;;;;
+91-05;bus;;;;
+91-06;bus;;;;
+91-07;bus;;;;
+91-08;bus;;;;
+91-09;bus;;;;
+91-10;bus;;;;
+91-11;bus;;;;

--- a/FR-IDF-albatrans/settings.sh
+++ b/FR-IDF-albatrans/settings.sh
@@ -1,0 +1,31 @@
+
+#!/bin/bash
+
+#
+# set variales for analysis of network
+#
+
+PREFIX="FR-IDF-albatrans"
+
+OVERPASS_QUERY="http://overpass-api.de/api/interpreter?data=area[wikidata=Q13917][type=boundary];(rel(area)[route~'bus'];rel(br);rel[type='route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r.routes);node(r.routes););out;"
+NETWORK_LONG=""
+NETWORK_SHORT="Albatrans"
+
+ANALYSIS_PAGE=""
+ANALYSIS_TALK=""
+#
+# Routes data is in GitHub only, not in OSM-Wiki
+#
+WIKI_ROUTES_PAGE=""
+
+ANALYSIS_OPTIONS="--check-access --check-bus-stop --check-name --check-osm-separator --check-sequence --check-stop-position --check-version --coloured-sketchline --check-motorway-link --max-error=10 --multiple-ref-type-entries=analyze --positive-notes"
+
+# --language=en
+# --check-bus-stop 
+# --expect-network-short
+# --expect-network-long
+# --expect-network-short-for=
+# --expect-network-long-for=
+# --relaxed-begin-end-for=
+
+    

--- a/FR-IDF-apolo-7/FR-IDF-apolo-7-Routes.txt
+++ b/FR-IDF-apolo-7/FR-IDF-apolo-7-Routes.txt
@@ -1,0 +1,67 @@
+
+#
+# This data is *not* stored in the OSM Wiki but in GitHub 
+#
+# Format: format is like in the OSM Wiki
+#
+# Links: [[...|...]] are interne link like in the OSM Wiki
+#        [... ...] are external links
+#
+# Headers start with '=', '==', '===', '====', ... at the beginning of a line
+#
+# Simple text starts with '-' at the beginning of a line.
+#    A single '-' at the beginning of a line, followed by nothing:
+#    - if there was simple text before, it creates a line feed (i.e. encloses the text in a paragraph <p> ... </p>)
+#    - if there was no simple text before or a line feed, it creates an empty line (i.e. <p>&amp;nbsp;</p>)
+#
+# !!!Text yellow background!!! in simple text or headers
+# '''''Text mit bold and italics''''' in simple text or headers
+# '''Text with bold chars''' in simple text or headers
+# ''Text with italic chars'' in simple text or headers
+#
+# Comments start with '#' at the beginning of a line. '#' inside text is not recognized as the start of a comment, i.e.. '#' may occur inside of text.
+#
+# Format of the file: UTF-8
+#
+#
+# Contents in CSV-Format - if ';' is part of the field, then enclose that field in "..."
+#
+# ref;type;comment;from;to;operator
+#
+# - ref       == tag 'ref' of route or route_master
+#                250            defines that routes with 'ref'='250' are expected
+#                250|250a|250b  defines that routes with 'ref'='250' or 'ref'='250a' or 'ref'='250b' are expected - independent of whether this is allowed according to PTv1/PTv2
+# - type      == contents of tags 'route' respectively 'route_master'
+# - comment   == can include comments like; Bus, Expressbus, ...  will not be analyzed, but simply be printed out
+#                !Text with yellow background! in comment (surrounded by single !)
+# - from      == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - to        == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - operator  == if there is more than one entry with "ref;type", then "operator" is used to distinguish between same line number in different cities/villages
+#
+
+
+= Overview on '''Apolo 7''' Public Transport Lines
+
+-
+- '''!!!This summary is a list of what has been published in open data by Île-de-France Mobilités and found in OSM!!!'''
+-
+- Feel free to modify the list on github
+-
+#
+#ref;type;comment;from;to;operator
+
+== Lines
+1;bus;;;;
+2;bus;;;;
+3;bus;;;;
+3s;bus;;;;
+4;bus;;;;
+4s;bus;;;;
+5;bus;;;;
+6;bus;;;;
+7;bus;;;;
+7s;bus;;;;
+8;bus;;;;
+8s;bus;;;;
+9;bus;;;;
+9s;bus;;;;

--- a/FR-IDF-apolo-7/settings.sh
+++ b/FR-IDF-apolo-7/settings.sh
@@ -1,0 +1,31 @@
+
+#!/bin/bash
+
+#
+# set variales for analysis of network
+#
+
+PREFIX="FR-IDF-apolo-7"
+
+OVERPASS_QUERY="http://overpass-api.de/api/interpreter?data=area[wikidata=Q13917][type=boundary];(rel(area)[route~'bus'];rel(br);rel[type='route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r.routes);node(r.routes););out;"
+NETWORK_LONG=""
+NETWORK_SHORT="Apolo 7"
+
+ANALYSIS_PAGE=""
+ANALYSIS_TALK=""
+#
+# Routes data is in GitHub only, not in OSM-Wiki
+#
+WIKI_ROUTES_PAGE=""
+
+ANALYSIS_OPTIONS="--check-access --check-bus-stop --check-name --check-osm-separator --check-sequence --check-stop-position --check-version --coloured-sketchline --check-motorway-link --max-error=10 --multiple-ref-type-entries=analyze --positive-notes"
+
+# --language=en
+# --check-bus-stop 
+# --expect-network-short
+# --expect-network-long
+# --expect-network-short-for=
+# --expect-network-long-for=
+# --relaxed-begin-end-for=
+
+    

--- a/FR-IDF-arlequin/FR-IDF-arlequin-Routes.txt
+++ b/FR-IDF-arlequin/FR-IDF-arlequin-Routes.txt
@@ -1,0 +1,63 @@
+
+#
+# This data is *not* stored in the OSM Wiki but in GitHub 
+#
+# Format: format is like in the OSM Wiki
+#
+# Links: [[...|...]] are interne link like in the OSM Wiki
+#        [... ...] are external links
+#
+# Headers start with '=', '==', '===', '====', ... at the beginning of a line
+#
+# Simple text starts with '-' at the beginning of a line.
+#    A single '-' at the beginning of a line, followed by nothing:
+#    - if there was simple text before, it creates a line feed (i.e. encloses the text in a paragraph <p> ... </p>)
+#    - if there was no simple text before or a line feed, it creates an empty line (i.e. <p>&amp;nbsp;</p>)
+#
+# !!!Text yellow background!!! in simple text or headers
+# '''''Text mit bold and italics''''' in simple text or headers
+# '''Text with bold chars''' in simple text or headers
+# ''Text with italic chars'' in simple text or headers
+#
+# Comments start with '#' at the beginning of a line. '#' inside text is not recognized as the start of a comment, i.e.. '#' may occur inside of text.
+#
+# Format of the file: UTF-8
+#
+#
+# Contents in CSV-Format - if ';' is part of the field, then enclose that field in "..."
+#
+# ref;type;comment;from;to;operator
+#
+# - ref       == tag 'ref' of route or route_master
+#                250            defines that routes with 'ref'='250' are expected
+#                250|250a|250b  defines that routes with 'ref'='250' or 'ref'='250a' or 'ref'='250b' are expected - independent of whether this is allowed according to PTv1/PTv2
+# - type      == contents of tags 'route' respectively 'route_master'
+# - comment   == can include comments like; Bus, Expressbus, ...  will not be analyzed, but simply be printed out
+#                !Text with yellow background! in comment (surrounded by single !)
+# - from      == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - to        == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - operator  == if there is more than one entry with "ref;type", then "operator" is used to distinguish between same line number in different cities/villages
+#
+
+
+= Overview on '''Arlequin''' Public Transport Lines
+
+-
+- '''!!!This summary is a list of what has been published in open data by Île-de-France Mobilités and found in OSM!!!'''
+-
+- Feel free to modify the list on github
+-
+#
+#ref;type;comment;from;to;operator
+
+== Lines
+05;bus;;;;
+06;bus;;;;
+10;bus;;;;
+12;bus;;;;
+14;bus;;;;
+21;bus;;;;
+30A;bus;;;;
+30B;bus;;;;
+30C;bus;;;;
+7;bus;;;;

--- a/FR-IDF-arlequin/settings.sh
+++ b/FR-IDF-arlequin/settings.sh
@@ -1,0 +1,31 @@
+
+#!/bin/bash
+
+#
+# set variales for analysis of network
+#
+
+PREFIX="FR-IDF-arlequin"
+
+OVERPASS_QUERY="http://overpass-api.de/api/interpreter?data=area[wikidata=Q13917][type=boundary];(rel(area)[route~'bus'];rel(br);rel[type='route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r.routes);node(r.routes););out;"
+NETWORK_LONG=""
+NETWORK_SHORT="Arlequin"
+
+ANALYSIS_PAGE=""
+ANALYSIS_TALK=""
+#
+# Routes data is in GitHub only, not in OSM-Wiki
+#
+WIKI_ROUTES_PAGE=""
+
+ANALYSIS_OPTIONS="--check-access --check-bus-stop --check-name --check-osm-separator --check-sequence --check-stop-position --check-version --coloured-sketchline --check-motorway-link --max-error=10 --multiple-ref-type-entries=analyze --positive-notes"
+
+# --language=en
+# --check-bus-stop 
+# --expect-network-short
+# --expect-network-long
+# --expect-network-short-for=
+# --expect-network-long-for=
+# --relaxed-begin-end-for=
+
+    

--- a/FR-IDF-bus-en-seine/FR-IDF-bus-en-seine-Routes.txt
+++ b/FR-IDF-bus-en-seine/FR-IDF-bus-en-seine-Routes.txt
@@ -1,0 +1,74 @@
+
+#
+# This data is *not* stored in the OSM Wiki but in GitHub 
+#
+# Format: format is like in the OSM Wiki
+#
+# Links: [[...|...]] are interne link like in the OSM Wiki
+#        [... ...] are external links
+#
+# Headers start with '=', '==', '===', '====', ... at the beginning of a line
+#
+# Simple text starts with '-' at the beginning of a line.
+#    A single '-' at the beginning of a line, followed by nothing:
+#    - if there was simple text before, it creates a line feed (i.e. encloses the text in a paragraph <p> ... </p>)
+#    - if there was no simple text before or a line feed, it creates an empty line (i.e. <p>&amp;nbsp;</p>)
+#
+# !!!Text yellow background!!! in simple text or headers
+# '''''Text mit bold and italics''''' in simple text or headers
+# '''Text with bold chars''' in simple text or headers
+# ''Text with italic chars'' in simple text or headers
+#
+# Comments start with '#' at the beginning of a line. '#' inside text is not recognized as the start of a comment, i.e.. '#' may occur inside of text.
+#
+# Format of the file: UTF-8
+#
+#
+# Contents in CSV-Format - if ';' is part of the field, then enclose that field in "..."
+#
+# ref;type;comment;from;to;operator
+#
+# - ref       == tag 'ref' of route or route_master
+#                250            defines that routes with 'ref'='250' are expected
+#                250|250a|250b  defines that routes with 'ref'='250' or 'ref'='250a' or 'ref'='250b' are expected - independent of whether this is allowed according to PTv1/PTv2
+# - type      == contents of tags 'route' respectively 'route_master'
+# - comment   == can include comments like; Bus, Expressbus, ...  will not be analyzed, but simply be printed out
+#                !Text with yellow background! in comment (surrounded by single !)
+# - from      == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - to        == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - operator  == if there is more than one entry with "ref;type", then "operator" is used to distinguish between same line number in different cities/villages
+#
+
+
+= Overview on '''Bus en Seine''' Public Transport Lines
+
+-
+- '''!!!This summary is a list of what has been published in open data by Île-de-France Mobilités and found in OSM!!!'''
+-
+- Feel free to modify the list on github
+-
+#
+#ref;type;comment;from;to;operator
+
+== Lines
+A;bus;;;;
+B;bus;;;;
+C;bus;;;;
+D;bus;;;;
+E;bus;;;;
+F;bus;;;;
+G;bus;;;;
+H;bus;;;;
+J;bus;;;;
+K;bus;;;;
+L;bus;;;;
+M;bus;;;;
+P;bus;;;;
+S1;bus;;;;
+S2;bus;;;;
+S3;bus;;;;
+S4;bus;;;;
+S5;bus;;;;
+S6;bus;;;;
+S7;bus;;;;
+T;bus;;;;

--- a/FR-IDF-bus-en-seine/settings.sh
+++ b/FR-IDF-bus-en-seine/settings.sh
@@ -1,0 +1,31 @@
+
+#!/bin/bash
+
+#
+# set variales for analysis of network
+#
+
+PREFIX="FR-IDF-bus-en-seine"
+
+OVERPASS_QUERY="http://overpass-api.de/api/interpreter?data=area[wikidata=Q13917][type=boundary];(rel(area)[route~'bus'];rel(br);rel[type='route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r.routes);node(r.routes););out;"
+NETWORK_LONG=""
+NETWORK_SHORT="Bus en Seine"
+
+ANALYSIS_PAGE=""
+ANALYSIS_TALK=""
+#
+# Routes data is in GitHub only, not in OSM-Wiki
+#
+WIKI_ROUTES_PAGE=""
+
+ANALYSIS_OPTIONS="--check-access --check-bus-stop --check-name --check-osm-separator --check-sequence --check-stop-position --check-version --coloured-sketchline --check-motorway-link --max-error=10 --multiple-ref-type-entries=analyze --positive-notes"
+
+# --language=en
+# --check-bus-stop 
+# --expect-network-short
+# --expect-network-long
+# --expect-network-short-for=
+# --expect-network-long-for=
+# --relaxed-begin-end-for=
+
+    

--- a/FR-IDF-busval-d-oise/FR-IDF-busval-d-oise-Routes.txt
+++ b/FR-IDF-busval-d-oise/FR-IDF-busval-d-oise-Routes.txt
@@ -1,0 +1,85 @@
+
+#
+# This data is *not* stored in the OSM Wiki but in GitHub 
+#
+# Format: format is like in the OSM Wiki
+#
+# Links: [[...|...]] are interne link like in the OSM Wiki
+#        [... ...] are external links
+#
+# Headers start with '=', '==', '===', '====', ... at the beginning of a line
+#
+# Simple text starts with '-' at the beginning of a line.
+#    A single '-' at the beginning of a line, followed by nothing:
+#    - if there was simple text before, it creates a line feed (i.e. encloses the text in a paragraph <p> ... </p>)
+#    - if there was no simple text before or a line feed, it creates an empty line (i.e. <p>&amp;nbsp;</p>)
+#
+# !!!Text yellow background!!! in simple text or headers
+# '''''Text mit bold and italics''''' in simple text or headers
+# '''Text with bold chars''' in simple text or headers
+# ''Text with italic chars'' in simple text or headers
+#
+# Comments start with '#' at the beginning of a line. '#' inside text is not recognized as the start of a comment, i.e.. '#' may occur inside of text.
+#
+# Format of the file: UTF-8
+#
+#
+# Contents in CSV-Format - if ';' is part of the field, then enclose that field in "..."
+#
+# ref;type;comment;from;to;operator
+#
+# - ref       == tag 'ref' of route or route_master
+#                250            defines that routes with 'ref'='250' are expected
+#                250|250a|250b  defines that routes with 'ref'='250' or 'ref'='250a' or 'ref'='250b' are expected - independent of whether this is allowed according to PTv1/PTv2
+# - type      == contents of tags 'route' respectively 'route_master'
+# - comment   == can include comments like; Bus, Expressbus, ...  will not be analyzed, but simply be printed out
+#                !Text with yellow background! in comment (surrounded by single !)
+# - from      == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - to        == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - operator  == if there is more than one entry with "ref;type", then "operator" is used to distinguish between same line number in different cities/villages
+#
+
+
+= Overview on '''Busval d'Oise''' Public Transport Lines
+
+-
+- '''!!!This summary is a list of what has been published in open data by Île-de-France Mobilités and found in OSM!!!'''
+-
+- Feel free to modify the list on github
+-
+#
+#ref;type;comment;from;to;operator
+
+== Lines
+100P;bus;;;;
+95-01;bus;;;;
+95-02;bus;;;;
+95-04;bus;;;;
+95-05;bus;;;;
+95-06;bus;;;;
+95-07;bus;;;;
+95-08;bus;;;;
+95-09;bus;;;;
+95-10;bus;;;;
+95-11;bus;;;;
+95-12;bus;;;;
+95-16;bus;;;;
+95-17;bus;;;;
+95-22;bus;;;;
+95-23;bus;;;;
+95-24;bus;;;;
+95-25;bus;;;;
+95-26;bus;;;;
+95-31;bus;;;;
+95-32;bus;;;;
+95-33;bus;;;;
+95-34;bus;;;;
+95-35;bus;;;;
+95-41;bus;;;;
+95-42;bus;;;;
+95-43;bus;;;;
+95-44;bus;;;;
+95-45;bus;;;;
+95-46;bus;;;;
+95-47;bus;;;;
+95-48;bus;;;;

--- a/FR-IDF-busval-d-oise/settings.sh
+++ b/FR-IDF-busval-d-oise/settings.sh
@@ -1,0 +1,31 @@
+
+#!/bin/bash
+
+#
+# set variales for analysis of network
+#
+
+PREFIX="FR-IDF-busval-d-oise"
+
+OVERPASS_QUERY="http://overpass-api.de/api/interpreter?data=area[wikidata=Q13917][type=boundary];(rel(area)[route~'bus'];rel(br);rel[type='route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r.routes);node(r.routes););out;"
+NETWORK_LONG=""
+NETWORK_SHORT="Busval d'Oise"
+
+ANALYSIS_PAGE=""
+ANALYSIS_TALK=""
+#
+# Routes data is in GitHub only, not in OSM-Wiki
+#
+WIKI_ROUTES_PAGE=""
+
+ANALYSIS_OPTIONS="--check-access --check-bus-stop --check-name --check-osm-separator --check-sequence --check-stop-position --check-version --coloured-sketchline --check-motorway-link --max-error=10 --multiple-ref-type-entries=analyze --positive-notes"
+
+# --language=en
+# --check-bus-stop 
+# --expect-network-short
+# --expect-network-long
+# --expect-network-short-for=
+# --expect-network-long-for=
+# --relaxed-begin-end-for=
+
+    

--- a/FR-IDF-cars-moreau/FR-IDF-cars-moreau-Routes.txt
+++ b/FR-IDF-cars-moreau/FR-IDF-cars-moreau-Routes.txt
@@ -1,0 +1,73 @@
+
+#
+# This data is *not* stored in the OSM Wiki but in GitHub 
+#
+# Format: format is like in the OSM Wiki
+#
+# Links: [[...|...]] are interne link like in the OSM Wiki
+#        [... ...] are external links
+#
+# Headers start with '=', '==', '===', '====', ... at the beginning of a line
+#
+# Simple text starts with '-' at the beginning of a line.
+#    A single '-' at the beginning of a line, followed by nothing:
+#    - if there was simple text before, it creates a line feed (i.e. encloses the text in a paragraph <p> ... </p>)
+#    - if there was no simple text before or a line feed, it creates an empty line (i.e. <p>&amp;nbsp;</p>)
+#
+# !!!Text yellow background!!! in simple text or headers
+# '''''Text mit bold and italics''''' in simple text or headers
+# '''Text with bold chars''' in simple text or headers
+# ''Text with italic chars'' in simple text or headers
+#
+# Comments start with '#' at the beginning of a line. '#' inside text is not recognized as the start of a comment, i.e.. '#' may occur inside of text.
+#
+# Format of the file: UTF-8
+#
+#
+# Contents in CSV-Format - if ';' is part of the field, then enclose that field in "..."
+#
+# ref;type;comment;from;to;operator
+#
+# - ref       == tag 'ref' of route or route_master
+#                250            defines that routes with 'ref'='250' are expected
+#                250|250a|250b  defines that routes with 'ref'='250' or 'ref'='250a' or 'ref'='250b' are expected - independent of whether this is allowed according to PTv1/PTv2
+# - type      == contents of tags 'route' respectively 'route_master'
+# - comment   == can include comments like; Bus, Expressbus, ...  will not be analyzed, but simply be printed out
+#                !Text with yellow background! in comment (surrounded by single !)
+# - from      == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - to        == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - operator  == if there is more than one entry with "ref;type", then "operator" is used to distinguish between same line number in different cities/villages
+#
+
+
+= Overview on '''CARS MOREAU''' Public Transport Lines
+
+-
+- '''!!!This summary is a list of what has been published in open data by Île-de-France Mobilités and found in OSM!!!'''
+-
+- Feel free to modify the list on github
+-
+#
+#ref;type;comment;from;to;operator
+
+== Lines
+001;bus;;;;
+001;bus;;;;
+002;bus;;;;
+003;bus;;;;
+003;bus;;;;
+116;bus;;;;
+201;bus;;;;
+202;bus;;;;
+203;bus;;;;
+204;bus;;;;
+211;bus;;;;
+4 A;bus;;;;
+4 B;bus;;;;
+4 B+D;bus;;;;
+4 C;bus;;;;
+4 D;bus;;;;
+4 E;bus;;;;
+BRAY 11;bus;;;;
+BRAY 3;bus;;;;
+BRAY 9;bus;;;;

--- a/FR-IDF-cars-moreau/settings.sh
+++ b/FR-IDF-cars-moreau/settings.sh
@@ -1,0 +1,31 @@
+
+#!/bin/bash
+
+#
+# set variales for analysis of network
+#
+
+PREFIX="FR-IDF-cars-moreau"
+
+OVERPASS_QUERY="http://overpass-api.de/api/interpreter?data=area[wikidata=Q13917][type=boundary];(rel(area)[route~'bus'];rel(br);rel[type='route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r.routes);node(r.routes););out;"
+NETWORK_LONG=""
+NETWORK_SHORT="CARS MOREAU"
+
+ANALYSIS_PAGE=""
+ANALYSIS_TALK=""
+#
+# Routes data is in GitHub only, not in OSM-Wiki
+#
+WIKI_ROUTES_PAGE=""
+
+ANALYSIS_OPTIONS="--check-access --check-bus-stop --check-name --check-osm-separator --check-sequence --check-stop-position --check-version --coloured-sketchline --check-motorway-link --max-error=10 --multiple-ref-type-entries=analyze --positive-notes"
+
+# --language=en
+# --check-bus-stop 
+# --expect-network-short
+# --expect-network-long
+# --expect-network-short-for=
+# --expect-network-long-for=
+# --relaxed-begin-end-for=
+
+    

--- a/FR-IDF-ceat/FR-IDF-ceat-Routes.txt
+++ b/FR-IDF-ceat/FR-IDF-ceat-Routes.txt
@@ -1,0 +1,83 @@
+
+#
+# This data is *not* stored in the OSM Wiki but in GitHub 
+#
+# Format: format is like in the OSM Wiki
+#
+# Links: [[...|...]] are interne link like in the OSM Wiki
+#        [... ...] are external links
+#
+# Headers start with '=', '==', '===', '====', ... at the beginning of a line
+#
+# Simple text starts with '-' at the beginning of a line.
+#    A single '-' at the beginning of a line, followed by nothing:
+#    - if there was simple text before, it creates a line feed (i.e. encloses the text in a paragraph <p> ... </p>)
+#    - if there was no simple text before or a line feed, it creates an empty line (i.e. <p>&amp;nbsp;</p>)
+#
+# !!!Text yellow background!!! in simple text or headers
+# '''''Text mit bold and italics''''' in simple text or headers
+# '''Text with bold chars''' in simple text or headers
+# ''Text with italic chars'' in simple text or headers
+#
+# Comments start with '#' at the beginning of a line. '#' inside text is not recognized as the start of a comment, i.e.. '#' may occur inside of text.
+#
+# Format of the file: UTF-8
+#
+#
+# Contents in CSV-Format - if ';' is part of the field, then enclose that field in "..."
+#
+# ref;type;comment;from;to;operator
+#
+# - ref       == tag 'ref' of route or route_master
+#                250            defines that routes with 'ref'='250' are expected
+#                250|250a|250b  defines that routes with 'ref'='250' or 'ref'='250a' or 'ref'='250b' are expected - independent of whether this is allowed according to PTv1/PTv2
+# - type      == contents of tags 'route' respectively 'route_master'
+# - comment   == can include comments like; Bus, Expressbus, ...  will not be analyzed, but simply be printed out
+#                !Text with yellow background! in comment (surrounded by single !)
+# - from      == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - to        == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - operator  == if there is more than one entry with "ref;type", then "operator" is used to distinguish between same line number in different cities/villages
+#
+
+
+= Overview on '''CEAT''' Public Transport Lines
+
+-
+- '''!!!This summary is a list of what has been published in open data by Île-de-France Mobilités and found in OSM!!!'''
+-
+- Feel free to modify the list on github
+-
+#
+#ref;type;comment;from;to;operator
+
+== Lines
+1001;bus;;;;
+101;bus;;;;
+102;bus;;;;
+1025;bus;;;;
+104;bus;;;;
+107;bus;;;;
+108;bus;;;;
+109;bus;;;;
+114;bus;;;;
+116;bus;;;;
+15;bus;;;;
+205;bus;;;;
+206A;bus;;;;
+206B;bus;;;;
+221;bus;;;;
+222;bus;;;;
+223;bus;;;;
+224;bus;;;;
+225;bus;;;;
+226;bus;;;;
+316;bus;;;;
+317;bus;;;;
+318;bus;;;;
+319;bus;;;;
+320;bus;;;;
+321;bus;;;;
+322;bus;;;;
+323;bus;;;;
+330;bus;;;;
+331;bus;;;;

--- a/FR-IDF-ceat/settings.sh
+++ b/FR-IDF-ceat/settings.sh
@@ -1,0 +1,31 @@
+
+#!/bin/bash
+
+#
+# set variales for analysis of network
+#
+
+PREFIX="FR-IDF-ceat"
+
+OVERPASS_QUERY="http://overpass-api.de/api/interpreter?data=area[wikidata=Q13917][type=boundary];(rel(area)[route~'bus'];rel(br);rel[type='route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r.routes);node(r.routes););out;"
+NETWORK_LONG=""
+NETWORK_SHORT="CEAT"
+
+ANALYSIS_PAGE=""
+ANALYSIS_TALK=""
+#
+# Routes data is in GitHub only, not in OSM-Wiki
+#
+WIKI_ROUTES_PAGE=""
+
+ANALYSIS_OPTIONS="--check-access --check-bus-stop --check-name --check-osm-separator --check-sequence --check-stop-position --check-version --coloured-sketchline --check-motorway-link --max-error=10 --multiple-ref-type-entries=analyze --positive-notes"
+
+# --language=en
+# --check-bus-stop 
+# --expect-network-short
+# --expect-network-long
+# --expect-network-short-for=
+# --expect-network-long-for=
+# --relaxed-begin-end-for=
+
+    

--- a/FR-IDF-cif/FR-IDF-cif-Routes.txt
+++ b/FR-IDF-cif/FR-IDF-cif-Routes.txt
@@ -1,0 +1,120 @@
+
+#
+# This data is *not* stored in the OSM Wiki but in GitHub 
+#
+# Format: format is like in the OSM Wiki
+#
+# Links: [[...|...]] are interne link like in the OSM Wiki
+#        [... ...] are external links
+#
+# Headers start with '=', '==', '===', '====', ... at the beginning of a line
+#
+# Simple text starts with '-' at the beginning of a line.
+#    A single '-' at the beginning of a line, followed by nothing:
+#    - if there was simple text before, it creates a line feed (i.e. encloses the text in a paragraph <p> ... </p>)
+#    - if there was no simple text before or a line feed, it creates an empty line (i.e. <p>&amp;nbsp;</p>)
+#
+# !!!Text yellow background!!! in simple text or headers
+# '''''Text mit bold and italics''''' in simple text or headers
+# '''Text with bold chars''' in simple text or headers
+# ''Text with italic chars'' in simple text or headers
+#
+# Comments start with '#' at the beginning of a line. '#' inside text is not recognized as the start of a comment, i.e.. '#' may occur inside of text.
+#
+# Format of the file: UTF-8
+#
+#
+# Contents in CSV-Format - if ';' is part of the field, then enclose that field in "..."
+#
+# ref;type;comment;from;to;operator
+#
+# - ref       == tag 'ref' of route or route_master
+#                250            defines that routes with 'ref'='250' are expected
+#                250|250a|250b  defines that routes with 'ref'='250' or 'ref'='250a' or 'ref'='250b' are expected - independent of whether this is allowed according to PTv1/PTv2
+# - type      == contents of tags 'route' respectively 'route_master'
+# - comment   == can include comments like; Bus, Expressbus, ...  will not be analyzed, but simply be printed out
+#                !Text with yellow background! in comment (surrounded by single !)
+# - from      == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - to        == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - operator  == if there is more than one entry with "ref;type", then "operator" is used to distinguish between same line number in different cities/villages
+#
+
+
+= Overview on '''CIF''' Public Transport Lines
+
+-
+- '''!!!This summary is a list of what has been published in open data by Île-de-France Mobilités and found in OSM!!!'''
+-
+- Feel free to modify the list on github
+-
+#
+#ref;type;comment;from;to;operator
+
+== Lines
+1;bus;;;;
+11;bus;;;;
+11.5;bus;;;;
+116;bus;;;;
+12;bus;;;;
+12.1;bus;;;;
+12ZI;bus;;;;
+14;bus;;;;
+14.1;bus;;;;
+15;bus;;;;
+16;bus;;;;
+17;bus;;;;
+171;bus;;;;
+18;bus;;;;
+19;bus;;;;
+21;bus;;;;
+22;bus;;;;
+23;bus;;;;
+24;bus;;;;
+30B;bus;;;;
+30D;bus;;;;
+31;bus;;;;
+32;bus;;;;
+32A;bus;;;;
+32ZA;bus;;;;
+33;bus;;;;
+34;bus;;;;
+38;bus;;;;
+39;bus;;;;
+3A;bus;;;;
+3B;bus;;;;
+40;bus;;;;
+43;bus;;;;
+44;bus;;;;
+45;bus;;;;
+46;bus;;;;
+47;bus;;;;
+49;bus;;;;
+50;bus;;;;
+71;bus;;;;
+777;bus;;;;
+93;bus;;;;
+FLEXO;bus;;;;
+G'bus;bus;;;;
+R1;bus;;;;
+R104;bus;;;;
+R105;bus;;;;
+R106;bus;;;;
+R107;bus;;;;
+R108;bus;;;;
+R109;bus;;;;
+R110;bus;;;;
+R111;bus;;;;
+R112;bus;;;;
+R113;bus;;;;
+R114;bus;;;;
+R117;bus;;;;
+R2;bus;;;;
+R3;bus;;;;
+R4;bus;;;;
+R48;bus;;;;
+R5;bus;;;;
+R6;bus;;;;
+R7;bus;;;;
+R8;bus;;;;
+T'bus;bus;;;;
+Vitavil;bus;;;;

--- a/FR-IDF-cif/settings.sh
+++ b/FR-IDF-cif/settings.sh
@@ -1,0 +1,31 @@
+
+#!/bin/bash
+
+#
+# set variales for analysis of network
+#
+
+PREFIX="FR-IDF-cif"
+
+OVERPASS_QUERY="http://overpass-api.de/api/interpreter?data=area[wikidata=Q13917][type=boundary];(rel(area)[route~'bus'];rel(br);rel[type='route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r.routes);node(r.routes););out;"
+NETWORK_LONG=""
+NETWORK_SHORT="CIF"
+
+ANALYSIS_PAGE=""
+ANALYSIS_TALK=""
+#
+# Routes data is in GitHub only, not in OSM-Wiki
+#
+WIKI_ROUTES_PAGE=""
+
+ANALYSIS_OPTIONS="--check-access --check-bus-stop --check-name --check-osm-separator --check-sequence --check-stop-position --check-version --coloured-sketchline --check-motorway-link --max-error=10 --multiple-ref-type-entries=analyze --positive-notes"
+
+# --language=en
+# --check-bus-stop 
+# --expect-network-short
+# --expect-network-long
+# --expect-network-short-for=
+# --expect-network-long-for=
+# --relaxed-begin-end-for=
+
+    

--- a/FR-IDF-com-bus/FR-IDF-com-bus-Routes.txt
+++ b/FR-IDF-com-bus/FR-IDF-com-bus-Routes.txt
@@ -1,0 +1,84 @@
+
+#
+# This data is *not* stored in the OSM Wiki but in GitHub 
+#
+# Format: format is like in the OSM Wiki
+#
+# Links: [[...|...]] are interne link like in the OSM Wiki
+#        [... ...] are external links
+#
+# Headers start with '=', '==', '===', '====', ... at the beginning of a line
+#
+# Simple text starts with '-' at the beginning of a line.
+#    A single '-' at the beginning of a line, followed by nothing:
+#    - if there was simple text before, it creates a line feed (i.e. encloses the text in a paragraph <p> ... </p>)
+#    - if there was no simple text before or a line feed, it creates an empty line (i.e. <p>&amp;nbsp;</p>)
+#
+# !!!Text yellow background!!! in simple text or headers
+# '''''Text mit bold and italics''''' in simple text or headers
+# '''Text with bold chars''' in simple text or headers
+# ''Text with italic chars'' in simple text or headers
+#
+# Comments start with '#' at the beginning of a line. '#' inside text is not recognized as the start of a comment, i.e.. '#' may occur inside of text.
+#
+# Format of the file: UTF-8
+#
+#
+# Contents in CSV-Format - if ';' is part of the field, then enclose that field in "..."
+#
+# ref;type;comment;from;to;operator
+#
+# - ref       == tag 'ref' of route or route_master
+#                250            defines that routes with 'ref'='250' are expected
+#                250|250a|250b  defines that routes with 'ref'='250' or 'ref'='250a' or 'ref'='250b' are expected - independent of whether this is allowed according to PTv1/PTv2
+# - type      == contents of tags 'route' respectively 'route_master'
+# - comment   == can include comments like; Bus, Expressbus, ...  will not be analyzed, but simply be printed out
+#                !Text with yellow background! in comment (surrounded by single !)
+# - from      == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - to        == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - operator  == if there is more than one entry with "ref;type", then "operator" is used to distinguish between same line number in different cities/villages
+#
+
+
+= Overview on '''Com'Bus''' Public Transport Lines
+
+-
+- '''!!!This summary is a list of what has been published in open data by Île-de-France Mobilités and found in OSM!!!'''
+-
+- Feel free to modify the list on github
+-
+#
+#ref;type;comment;from;to;operator
+
+== Lines
+01;bus;;;;
+02A;bus;;;;
+02B;bus;;;;
+02C;bus;;;;
+04;bus;;;;
+05;bus;;;;
+07;bus;;;;
+09;bus;;;;
+10;bus;;;;
+109;bus;;;;
+110;bus;;;;
+15;bus;;;;
+16;bus;;;;
+17;bus;;;;
+18;bus;;;;
+19;bus;;;;
+20;bus;;;;
+21;bus;;;;
+22;bus;;;;
+26;bus;;;;
+52;bus;;;;
+81;bus;;;;
+82;bus;;;;
+89;bus;;;;
+90;bus;;;;
+91;bus;;;;
+91;bus;;;;
+L;bus;;;;
+N;bus;;;;
+P;bus;;;;
+R;bus;;;;

--- a/FR-IDF-com-bus/settings.sh
+++ b/FR-IDF-com-bus/settings.sh
@@ -1,0 +1,31 @@
+
+#!/bin/bash
+
+#
+# set variales for analysis of network
+#
+
+PREFIX="FR-IDF-com-bus"
+
+OVERPASS_QUERY="http://overpass-api.de/api/interpreter?data=area[wikidata=Q13917][type=boundary];(rel(area)[route~'bus'];rel(br);rel[type='route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r.routes);node(r.routes););out;"
+NETWORK_LONG=""
+NETWORK_SHORT="Com'Bus"
+
+ANALYSIS_PAGE=""
+ANALYSIS_TALK=""
+#
+# Routes data is in GitHub only, not in OSM-Wiki
+#
+WIKI_ROUTES_PAGE=""
+
+ANALYSIS_OPTIONS="--check-access --check-bus-stop --check-name --check-osm-separator --check-sequence --check-stop-position --check-version --coloured-sketchline --check-motorway-link --max-error=10 --multiple-ref-type-entries=analyze --positive-notes"
+
+# --language=en
+# --check-bus-stop 
+# --expect-network-short
+# --expect-network-long
+# --expect-network-short-for=
+# --expect-network-long-for=
+# --relaxed-begin-end-for=
+
+    

--- a/FR-IDF-comete/FR-IDF-comete-Routes.txt
+++ b/FR-IDF-comete/FR-IDF-comete-Routes.txt
@@ -1,0 +1,64 @@
+
+#
+# This data is *not* stored in the OSM Wiki but in GitHub 
+#
+# Format: format is like in the OSM Wiki
+#
+# Links: [[...|...]] are interne link like in the OSM Wiki
+#        [... ...] are external links
+#
+# Headers start with '=', '==', '===', '====', ... at the beginning of a line
+#
+# Simple text starts with '-' at the beginning of a line.
+#    A single '-' at the beginning of a line, followed by nothing:
+#    - if there was simple text before, it creates a line feed (i.e. encloses the text in a paragraph <p> ... </p>)
+#    - if there was no simple text before or a line feed, it creates an empty line (i.e. <p>&amp;nbsp;</p>)
+#
+# !!!Text yellow background!!! in simple text or headers
+# '''''Text mit bold and italics''''' in simple text or headers
+# '''Text with bold chars''' in simple text or headers
+# ''Text with italic chars'' in simple text or headers
+#
+# Comments start with '#' at the beginning of a line. '#' inside text is not recognized as the start of a comment, i.e.. '#' may occur inside of text.
+#
+# Format of the file: UTF-8
+#
+#
+# Contents in CSV-Format - if ';' is part of the field, then enclose that field in "..."
+#
+# ref;type;comment;from;to;operator
+#
+# - ref       == tag 'ref' of route or route_master
+#                250            defines that routes with 'ref'='250' are expected
+#                250|250a|250b  defines that routes with 'ref'='250' or 'ref'='250a' or 'ref'='250b' are expected - independent of whether this is allowed according to PTv1/PTv2
+# - type      == contents of tags 'route' respectively 'route_master'
+# - comment   == can include comments like; Bus, Expressbus, ...  will not be analyzed, but simply be printed out
+#                !Text with yellow background! in comment (surrounded by single !)
+# - from      == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - to        == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - operator  == if there is more than one entry with "ref;type", then "operator" is used to distinguish between same line number in different cities/villages
+#
+
+
+= Overview on '''Comète''' Public Transport Lines
+
+-
+- '''!!!This summary is a list of what has been published in open data by Île-de-France Mobilités and found in OSM!!!'''
+-
+- Feel free to modify the list on github
+-
+#
+#ref;type;comment;from;to;operator
+
+== Lines
+201;bus;;;;
+202;bus;;;;
+203;bus;;;;
+204;bus;;;;
+205;bus;;;;
+206;bus;;;;
+207;bus;;;;
+208;bus;;;;
+209;bus;;;;
+210;bus;;;;
+211;bus;;;;

--- a/FR-IDF-comete/settings.sh
+++ b/FR-IDF-comete/settings.sh
@@ -1,0 +1,31 @@
+
+#!/bin/bash
+
+#
+# set variales for analysis of network
+#
+
+PREFIX="FR-IDF-comete"
+
+OVERPASS_QUERY="http://overpass-api.de/api/interpreter?data=area[wikidata=Q13917][type=boundary];(rel(area)[route~'bus'];rel(br);rel[type='route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r.routes);node(r.routes););out;"
+NETWORK_LONG=""
+NETWORK_SHORT="Comète"
+
+ANALYSIS_PAGE=""
+ANALYSIS_TALK=""
+#
+# Routes data is in GitHub only, not in OSM-Wiki
+#
+WIKI_ROUTES_PAGE=""
+
+ANALYSIS_OPTIONS="--check-access --check-bus-stop --check-name --check-osm-separator --check-sequence --check-stop-position --check-version --coloured-sketchline --check-motorway-link --max-error=10 --multiple-ref-type-entries=analyze --positive-notes"
+
+# --language=en
+# --check-bus-stop 
+# --expect-network-short
+# --expect-network-long
+# --expect-network-short-for=
+# --expect-network-long-for=
+# --relaxed-begin-end-for=
+
+    

--- a/FR-IDF-cso/FR-IDF-cso-Routes.txt
+++ b/FR-IDF-cso/FR-IDF-cso-Routes.txt
@@ -1,0 +1,76 @@
+
+#
+# This data is *not* stored in the OSM Wiki but in GitHub 
+#
+# Format: format is like in the OSM Wiki
+#
+# Links: [[...|...]] are interne link like in the OSM Wiki
+#        [... ...] are external links
+#
+# Headers start with '=', '==', '===', '====', ... at the beginning of a line
+#
+# Simple text starts with '-' at the beginning of a line.
+#    A single '-' at the beginning of a line, followed by nothing:
+#    - if there was simple text before, it creates a line feed (i.e. encloses the text in a paragraph <p> ... </p>)
+#    - if there was no simple text before or a line feed, it creates an empty line (i.e. <p>&amp;nbsp;</p>)
+#
+# !!!Text yellow background!!! in simple text or headers
+# '''''Text mit bold and italics''''' in simple text or headers
+# '''Text with bold chars''' in simple text or headers
+# ''Text with italic chars'' in simple text or headers
+#
+# Comments start with '#' at the beginning of a line. '#' inside text is not recognized as the start of a comment, i.e.. '#' may occur inside of text.
+#
+# Format of the file: UTF-8
+#
+#
+# Contents in CSV-Format - if ';' is part of the field, then enclose that field in "..."
+#
+# ref;type;comment;from;to;operator
+#
+# - ref       == tag 'ref' of route or route_master
+#                250            defines that routes with 'ref'='250' are expected
+#                250|250a|250b  defines that routes with 'ref'='250' or 'ref'='250a' or 'ref'='250b' are expected - independent of whether this is allowed according to PTv1/PTv2
+# - type      == contents of tags 'route' respectively 'route_master'
+# - comment   == can include comments like; Bus, Expressbus, ...  will not be analyzed, but simply be printed out
+#                !Text with yellow background! in comment (surrounded by single !)
+# - from      == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - to        == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - operator  == if there is more than one entry with "ref;type", then "operator" is used to distinguish between same line number in different cities/villages
+#
+
+
+= Overview on '''CSO''' Public Transport Lines
+
+-
+- '''!!!This summary is a list of what has been published in open data by Île-de-France Mobilités and found in OSM!!!'''
+-
+- Feel free to modify the list on github
+-
+#
+#ref;type;comment;from;to;operator
+
+== Lines
+1;bus;;;;
+10;bus;;;;
+11;bus;;;;
+14;bus;;;;
+16;bus;;;;
+2;bus;;;;
+20;bus;;;;
+21;bus;;;;
+23;bus;;;;
+24;bus;;;;
+25;bus;;;;
+27;bus;;;;
+28;bus;;;;
+4;bus;;;;
+50;bus;;;;
+51;bus;;;;
+52;bus;;;;
+54;bus;;;;
+55;bus;;;;
+6;bus;;;;
+7;bus;;;;
+9;bus;;;;
+98;bus;;;;

--- a/FR-IDF-cso/settings.sh
+++ b/FR-IDF-cso/settings.sh
@@ -1,0 +1,31 @@
+
+#!/bin/bash
+
+#
+# set variales for analysis of network
+#
+
+PREFIX="FR-IDF-cso"
+
+OVERPASS_QUERY="http://overpass-api.de/api/interpreter?data=area[wikidata=Q13917][type=boundary];(rel(area)[route~'bus'];rel(br);rel[type='route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r.routes);node(r.routes););out;"
+NETWORK_LONG=""
+NETWORK_SHORT="CSO"
+
+ANALYSIS_PAGE=""
+ANALYSIS_TALK=""
+#
+# Routes data is in GitHub only, not in OSM-Wiki
+#
+WIKI_ROUTES_PAGE=""
+
+ANALYSIS_OPTIONS="--check-access --check-bus-stop --check-name --check-osm-separator --check-sequence --check-stop-position --check-version --coloured-sketchline --check-motorway-link --max-error=10 --multiple-ref-type-entries=analyze --positive-notes"
+
+# --language=en
+# --check-bus-stop 
+# --expect-network-short
+# --expect-network-long
+# --expect-network-short-for=
+# --expect-network-long-for=
+# --relaxed-begin-end-for=
+
+    

--- a/FR-IDF-entre-seine-et-foret/FR-IDF-entre-seine-et-foret-Routes.txt
+++ b/FR-IDF-entre-seine-et-foret/FR-IDF-entre-seine-et-foret-Routes.txt
@@ -1,0 +1,63 @@
+
+#
+# This data is *not* stored in the OSM Wiki but in GitHub 
+#
+# Format: format is like in the OSM Wiki
+#
+# Links: [[...|...]] are interne link like in the OSM Wiki
+#        [... ...] are external links
+#
+# Headers start with '=', '==', '===', '====', ... at the beginning of a line
+#
+# Simple text starts with '-' at the beginning of a line.
+#    A single '-' at the beginning of a line, followed by nothing:
+#    - if there was simple text before, it creates a line feed (i.e. encloses the text in a paragraph <p> ... </p>)
+#    - if there was no simple text before or a line feed, it creates an empty line (i.e. <p>&amp;nbsp;</p>)
+#
+# !!!Text yellow background!!! in simple text or headers
+# '''''Text mit bold and italics''''' in simple text or headers
+# '''Text with bold chars''' in simple text or headers
+# ''Text with italic chars'' in simple text or headers
+#
+# Comments start with '#' at the beginning of a line. '#' inside text is not recognized as the start of a comment, i.e.. '#' may occur inside of text.
+#
+# Format of the file: UTF-8
+#
+#
+# Contents in CSV-Format - if ';' is part of the field, then enclose that field in "..."
+#
+# ref;type;comment;from;to;operator
+#
+# - ref       == tag 'ref' of route or route_master
+#                250            defines that routes with 'ref'='250' are expected
+#                250|250a|250b  defines that routes with 'ref'='250' or 'ref'='250a' or 'ref'='250b' are expected - independent of whether this is allowed according to PTv1/PTv2
+# - type      == contents of tags 'route' respectively 'route_master'
+# - comment   == can include comments like; Bus, Expressbus, ...  will not be analyzed, but simply be printed out
+#                !Text with yellow background! in comment (surrounded by single !)
+# - from      == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - to        == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - operator  == if there is more than one entry with "ref;type", then "operator" is used to distinguish between same line number in different cities/villages
+#
+
+
+= Overview on '''Entre Seine et Forêt''' Public Transport Lines
+
+-
+- '''!!!This summary is a list of what has been published in open data by Île-de-France Mobilités and found in OSM!!!'''
+-
+- Feel free to modify the list on github
+-
+#
+#ref;type;comment;from;to;operator
+
+== Lines
+10;bus;;;;
+15;bus;;;;
+18;bus;;;;
+18S;bus;;;;
+21;bus;;;;
+21M;bus;;;;
+9A;bus;;;;
+9AB;bus;;;;
+9B;bus;;;;
+9D;bus;;;;

--- a/FR-IDF-entre-seine-et-foret/settings.sh
+++ b/FR-IDF-entre-seine-et-foret/settings.sh
@@ -1,0 +1,31 @@
+
+#!/bin/bash
+
+#
+# set variales for analysis of network
+#
+
+PREFIX="FR-IDF-entre-seine-et-foret"
+
+OVERPASS_QUERY="http://overpass-api.de/api/interpreter?data=area[wikidata=Q13917][type=boundary];(rel(area)[route~'bus'];rel(br);rel[type='route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r.routes);node(r.routes););out;"
+NETWORK_LONG=""
+NETWORK_SHORT="Entre Seine et Forêt"
+
+ANALYSIS_PAGE=""
+ANALYSIS_TALK=""
+#
+# Routes data is in GitHub only, not in OSM-Wiki
+#
+WIKI_ROUTES_PAGE=""
+
+ANALYSIS_OPTIONS="--check-access --check-bus-stop --check-name --check-osm-separator --check-sequence --check-stop-position --check-version --coloured-sketchline --check-motorway-link --max-error=10 --multiple-ref-type-entries=analyze --positive-notes"
+
+# --language=en
+# --check-bus-stop 
+# --expect-network-short
+# --expect-network-long
+# --expect-network-short-for=
+# --expect-network-long-for=
+# --relaxed-begin-end-for=
+
+    

--- a/FR-IDF-fileo/FR-IDF-fileo-Routes.txt
+++ b/FR-IDF-fileo/FR-IDF-fileo-Routes.txt
@@ -1,0 +1,65 @@
+
+#
+# This data is *not* stored in the OSM Wiki but in GitHub 
+#
+# Format: format is like in the OSM Wiki
+#
+# Links: [[...|...]] are interne link like in the OSM Wiki
+#        [... ...] are external links
+#
+# Headers start with '=', '==', '===', '====', ... at the beginning of a line
+#
+# Simple text starts with '-' at the beginning of a line.
+#    A single '-' at the beginning of a line, followed by nothing:
+#    - if there was simple text before, it creates a line feed (i.e. encloses the text in a paragraph <p> ... </p>)
+#    - if there was no simple text before or a line feed, it creates an empty line (i.e. <p>&amp;nbsp;</p>)
+#
+# !!!Text yellow background!!! in simple text or headers
+# '''''Text mit bold and italics''''' in simple text or headers
+# '''Text with bold chars''' in simple text or headers
+# ''Text with italic chars'' in simple text or headers
+#
+# Comments start with '#' at the beginning of a line. '#' inside text is not recognized as the start of a comment, i.e.. '#' may occur inside of text.
+#
+# Format of the file: UTF-8
+#
+#
+# Contents in CSV-Format - if ';' is part of the field, then enclose that field in "..."
+#
+# ref;type;comment;from;to;operator
+#
+# - ref       == tag 'ref' of route or route_master
+#                250            defines that routes with 'ref'='250' are expected
+#                250|250a|250b  defines that routes with 'ref'='250' or 'ref'='250a' or 'ref'='250b' are expected - independent of whether this is allowed according to PTv1/PTv2
+# - type      == contents of tags 'route' respectively 'route_master'
+# - comment   == can include comments like; Bus, Expressbus, ...  will not be analyzed, but simply be printed out
+#                !Text with yellow background! in comment (surrounded by single !)
+# - from      == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - to        == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - operator  == if there is more than one entry with "ref;type", then "operator" is used to distinguish between same line number in different cities/villages
+#
+
+
+= Overview on '''Filéo''' Public Transport Lines
+
+-
+- '''!!!This summary is a list of what has been published in open data by Île-de-France Mobilités and found in OSM!!!'''
+-
+- Feel free to modify the list on github
+-
+#
+#ref;type;comment;from;to;operator
+
+== Lines
+27;bus;;;;
+32;bus;;;;
+FILEO FO;bus;;;;
+FILEO G;bus;;;;
+FILEO O;bus;;;;
+FILEO S;bus;;;;
+FILEO SL;bus;;;;
+FILEO SP;bus;;;;
+FILEO T;bus;;;;
+FILEO V;bus;;;;
+FILEO VB;bus;;;;
+FILEO VE;bus;;;;

--- a/FR-IDF-fileo/settings.sh
+++ b/FR-IDF-fileo/settings.sh
@@ -1,0 +1,31 @@
+
+#!/bin/bash
+
+#
+# set variales for analysis of network
+#
+
+PREFIX="FR-IDF-fileo"
+
+OVERPASS_QUERY="http://overpass-api.de/api/interpreter?data=area[wikidata=Q13917][type=boundary];(rel(area)[route~'bus'];rel(br);rel[type='route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r.routes);node(r.routes););out;"
+NETWORK_LONG=""
+NETWORK_SHORT="Filéo"
+
+ANALYSIS_PAGE=""
+ANALYSIS_TALK=""
+#
+# Routes data is in GitHub only, not in OSM-Wiki
+#
+WIKI_ROUTES_PAGE=""
+
+ANALYSIS_OPTIONS="--check-access --check-bus-stop --check-name --check-osm-separator --check-sequence --check-stop-position --check-version --coloured-sketchline --check-motorway-link --max-error=10 --multiple-ref-type-entries=analyze --positive-notes"
+
+# --language=en
+# --check-bus-stop 
+# --expect-network-short
+# --expect-network-long
+# --expect-network-short-for=
+# --expect-network-long-for=
+# --relaxed-begin-end-for=
+
+    

--- a/FR-IDF-goelys/FR-IDF-goelys-Routes.txt
+++ b/FR-IDF-goelys/FR-IDF-goelys-Routes.txt
@@ -1,0 +1,73 @@
+
+#
+# This data is *not* stored in the OSM Wiki but in GitHub 
+#
+# Format: format is like in the OSM Wiki
+#
+# Links: [[...|...]] are interne link like in the OSM Wiki
+#        [... ...] are external links
+#
+# Headers start with '=', '==', '===', '====', ... at the beginning of a line
+#
+# Simple text starts with '-' at the beginning of a line.
+#    A single '-' at the beginning of a line, followed by nothing:
+#    - if there was simple text before, it creates a line feed (i.e. encloses the text in a paragraph <p> ... </p>)
+#    - if there was no simple text before or a line feed, it creates an empty line (i.e. <p>&amp;nbsp;</p>)
+#
+# !!!Text yellow background!!! in simple text or headers
+# '''''Text mit bold and italics''''' in simple text or headers
+# '''Text with bold chars''' in simple text or headers
+# ''Text with italic chars'' in simple text or headers
+#
+# Comments start with '#' at the beginning of a line. '#' inside text is not recognized as the start of a comment, i.e.. '#' may occur inside of text.
+#
+# Format of the file: UTF-8
+#
+#
+# Contents in CSV-Format - if ';' is part of the field, then enclose that field in "..."
+#
+# ref;type;comment;from;to;operator
+#
+# - ref       == tag 'ref' of route or route_master
+#                250            defines that routes with 'ref'='250' are expected
+#                250|250a|250b  defines that routes with 'ref'='250' or 'ref'='250a' or 'ref'='250b' are expected - independent of whether this is allowed according to PTv1/PTv2
+# - type      == contents of tags 'route' respectively 'route_master'
+# - comment   == can include comments like; Bus, Expressbus, ...  will not be analyzed, but simply be printed out
+#                !Text with yellow background! in comment (surrounded by single !)
+# - from      == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - to        == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - operator  == if there is more than one entry with "ref;type", then "operator" is used to distinguish between same line number in different cities/villages
+#
+
+
+= Overview on '''Goëlys''' Public Transport Lines
+
+-
+- '''!!!This summary is a list of what has been published in open data by Île-de-France Mobilités and found in OSM!!!'''
+-
+- Feel free to modify the list on github
+-
+#
+#ref;type;comment;from;to;operator
+
+== Lines
+701;bus;;;;
+702;bus;;;;
+703;bus;;;;
+704;bus;;;;
+705;bus;;;;
+707;bus;;;;
+708;bus;;;;
+709;bus;;;;
+710;bus;;;;
+711;bus;;;;
+714;bus;;;;
+715;bus;;;;
+749 B;bus;;;;
+749 C;bus;;;;
+749 D;bus;;;;
+751;bus;;;;
+752;bus;;;;
+753;bus;;;;
+755;bus;;;;
+756;bus;;;;

--- a/FR-IDF-goelys/settings.sh
+++ b/FR-IDF-goelys/settings.sh
@@ -1,0 +1,31 @@
+
+#!/bin/bash
+
+#
+# set variales for analysis of network
+#
+
+PREFIX="FR-IDF-goelys"
+
+OVERPASS_QUERY="http://overpass-api.de/api/interpreter?data=area[wikidata=Q13917][type=boundary];(rel(area)[route~'bus'];rel(br);rel[type='route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r.routes);node(r.routes););out;"
+NETWORK_LONG=""
+NETWORK_SHORT="Goëlys"
+
+ANALYSIS_PAGE=""
+ANALYSIS_TALK=""
+#
+# Routes data is in GitHub only, not in OSM-Wiki
+#
+WIKI_ROUTES_PAGE=""
+
+ANALYSIS_OPTIONS="--check-access --check-bus-stop --check-name --check-osm-separator --check-sequence --check-stop-position --check-version --coloured-sketchline --check-motorway-link --max-error=10 --multiple-ref-type-entries=analyze --positive-notes"
+
+# --language=en
+# --check-bus-stop 
+# --expect-network-short
+# --expect-network-long
+# --expect-network-short-for=
+# --expect-network-long-for=
+# --relaxed-begin-end-for=
+
+    

--- a/FR-IDF-houdanais/FR-IDF-houdanais-Routes.txt
+++ b/FR-IDF-houdanais/FR-IDF-houdanais-Routes.txt
@@ -1,0 +1,73 @@
+
+#
+# This data is *not* stored in the OSM Wiki but in GitHub 
+#
+# Format: format is like in the OSM Wiki
+#
+# Links: [[...|...]] are interne link like in the OSM Wiki
+#        [... ...] are external links
+#
+# Headers start with '=', '==', '===', '====', ... at the beginning of a line
+#
+# Simple text starts with '-' at the beginning of a line.
+#    A single '-' at the beginning of a line, followed by nothing:
+#    - if there was simple text before, it creates a line feed (i.e. encloses the text in a paragraph <p> ... </p>)
+#    - if there was no simple text before or a line feed, it creates an empty line (i.e. <p>&amp;nbsp;</p>)
+#
+# !!!Text yellow background!!! in simple text or headers
+# '''''Text mit bold and italics''''' in simple text or headers
+# '''Text with bold chars''' in simple text or headers
+# ''Text with italic chars'' in simple text or headers
+#
+# Comments start with '#' at the beginning of a line. '#' inside text is not recognized as the start of a comment, i.e.. '#' may occur inside of text.
+#
+# Format of the file: UTF-8
+#
+#
+# Contents in CSV-Format - if ';' is part of the field, then enclose that field in "..."
+#
+# ref;type;comment;from;to;operator
+#
+# - ref       == tag 'ref' of route or route_master
+#                250            defines that routes with 'ref'='250' are expected
+#                250|250a|250b  defines that routes with 'ref'='250' or 'ref'='250a' or 'ref'='250b' are expected - independent of whether this is allowed according to PTv1/PTv2
+# - type      == contents of tags 'route' respectively 'route_master'
+# - comment   == can include comments like; Bus, Expressbus, ...  will not be analyzed, but simply be printed out
+#                !Text with yellow background! in comment (surrounded by single !)
+# - from      == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - to        == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - operator  == if there is more than one entry with "ref;type", then "operator" is used to distinguish between same line number in different cities/villages
+#
+
+
+= Overview on '''Houdanais''' Public Transport Lines
+
+-
+- '''!!!This summary is a list of what has been published in open data by Île-de-France Mobilités and found in OSM!!!'''
+-
+- Feel free to modify the list on github
+-
+#
+#ref;type;comment;from;to;operator
+
+== Lines
+15;bus;;;;
+16;bus;;;;
+17;bus;;;;
+2;bus;;;;
+21;bus;;;;
+22;bus;;;;
+31;bus;;;;
+35;bus;;;;
+38;bus;;;;
+40;bus;;;;
+41;bus;;;;
+45;bus;;;;
+48;bus;;;;
+51;bus;;;;
+55;bus;;;;
+60;bus;;;;
+61;bus;;;;
+65;bus;;;;
+67;bus;;;;
+9;bus;;;;

--- a/FR-IDF-houdanais/settings.sh
+++ b/FR-IDF-houdanais/settings.sh
@@ -1,0 +1,31 @@
+
+#!/bin/bash
+
+#
+# set variales for analysis of network
+#
+
+PREFIX="FR-IDF-houdanais"
+
+OVERPASS_QUERY="http://overpass-api.de/api/interpreter?data=area[wikidata=Q13917][type=boundary];(rel(area)[route~'bus'];rel(br);rel[type='route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r.routes);node(r.routes););out;"
+NETWORK_LONG=""
+NETWORK_SHORT="Houdanais"
+
+ANALYSIS_PAGE=""
+ANALYSIS_TALK=""
+#
+# Routes data is in GitHub only, not in OSM-Wiki
+#
+WIKI_ROUTES_PAGE=""
+
+ANALYSIS_OPTIONS="--check-access --check-bus-stop --check-name --check-osm-separator --check-sequence --check-stop-position --check-version --coloured-sketchline --check-motorway-link --max-error=10 --multiple-ref-type-entries=analyze --positive-notes"
+
+# --language=en
+# --check-bus-stop 
+# --expect-network-short
+# --expect-network-long
+# --expect-network-short-for=
+# --expect-network-long-for=
+# --relaxed-begin-end-for=
+
+    

--- a/FR-IDF-hourtoule/FR-IDF-hourtoule-Routes.txt
+++ b/FR-IDF-hourtoule/FR-IDF-hourtoule-Routes.txt
@@ -1,0 +1,80 @@
+
+#
+# This data is *not* stored in the OSM Wiki but in GitHub 
+#
+# Format: format is like in the OSM Wiki
+#
+# Links: [[...|...]] are interne link like in the OSM Wiki
+#        [... ...] are external links
+#
+# Headers start with '=', '==', '===', '====', ... at the beginning of a line
+#
+# Simple text starts with '-' at the beginning of a line.
+#    A single '-' at the beginning of a line, followed by nothing:
+#    - if there was simple text before, it creates a line feed (i.e. encloses the text in a paragraph <p> ... </p>)
+#    - if there was no simple text before or a line feed, it creates an empty line (i.e. <p>&amp;nbsp;</p>)
+#
+# !!!Text yellow background!!! in simple text or headers
+# '''''Text mit bold and italics''''' in simple text or headers
+# '''Text with bold chars''' in simple text or headers
+# ''Text with italic chars'' in simple text or headers
+#
+# Comments start with '#' at the beginning of a line. '#' inside text is not recognized as the start of a comment, i.e.. '#' may occur inside of text.
+#
+# Format of the file: UTF-8
+#
+#
+# Contents in CSV-Format - if ';' is part of the field, then enclose that field in "..."
+#
+# ref;type;comment;from;to;operator
+#
+# - ref       == tag 'ref' of route or route_master
+#                250            defines that routes with 'ref'='250' are expected
+#                250|250a|250b  defines that routes with 'ref'='250' or 'ref'='250a' or 'ref'='250b' are expected - independent of whether this is allowed according to PTv1/PTv2
+# - type      == contents of tags 'route' respectively 'route_master'
+# - comment   == can include comments like; Bus, Expressbus, ...  will not be analyzed, but simply be printed out
+#                !Text with yellow background! in comment (surrounded by single !)
+# - from      == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - to        == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - operator  == if there is more than one entry with "ref;type", then "operator" is used to distinguish between same line number in different cities/villages
+#
+
+
+= Overview on '''HOURTOULE''' Public Transport Lines
+
+-
+- '''!!!This summary is a list of what has been published in open data by Île-de-France Mobilités and found in OSM!!!'''
+-
+- Feel free to modify the list on github
+-
+#
+#ref;type;comment;from;to;operator
+
+== Lines
+10;bus;;;;
+11;bus;;;;
+111;bus;;;;
+12;bus;;;;
+14;bus;;;;
+15;bus;;;;
+17;bus;;;;
+19;bus;;;;
+20;bus;;;;
+41;bus;;;;
+5;bus;;;;
+50;bus;;;;
+6;bus;;;;
+7;bus;;;;
+78 EXPRES;bus;;;;
+8;bus;;;;
+9;bus;;;;
+AQ;bus;;;;
+B;bus;;;;
+BL;bus;;;;
+CSP;bus;;;;
+JV;bus;;;;
+M;bus;;;;
+P;bus;;;;
+Q;bus;;;;
+TG;bus;;;;
+V;bus;;;;

--- a/FR-IDF-hourtoule/settings.sh
+++ b/FR-IDF-hourtoule/settings.sh
@@ -1,0 +1,31 @@
+
+#!/bin/bash
+
+#
+# set variales for analysis of network
+#
+
+PREFIX="FR-IDF-hourtoule"
+
+OVERPASS_QUERY="http://overpass-api.de/api/interpreter?data=area[wikidata=Q13917][type=boundary];(rel(area)[route~'bus'];rel(br);rel[type='route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r.routes);node(r.routes););out;"
+NETWORK_LONG=""
+NETWORK_SHORT="HOURTOULE"
+
+ANALYSIS_PAGE=""
+ANALYSIS_TALK=""
+#
+# Routes data is in GitHub only, not in OSM-Wiki
+#
+WIKI_ROUTES_PAGE=""
+
+ANALYSIS_OPTIONS="--check-access --check-bus-stop --check-name --check-osm-separator --check-sequence --check-stop-position --check-version --coloured-sketchline --check-motorway-link --max-error=10 --multiple-ref-type-entries=analyze --positive-notes"
+
+# --language=en
+# --check-bus-stop 
+# --expect-network-short
+# --expect-network-long
+# --expect-network-short-for=
+# --expect-network-long-for=
+# --relaxed-begin-end-for=
+
+    

--- a/FR-IDF-lacroix/FR-IDF-lacroix-Routes.txt
+++ b/FR-IDF-lacroix/FR-IDF-lacroix-Routes.txt
@@ -1,0 +1,70 @@
+
+#
+# This data is *not* stored in the OSM Wiki but in GitHub 
+#
+# Format: format is like in the OSM Wiki
+#
+# Links: [[...|...]] are interne link like in the OSM Wiki
+#        [... ...] are external links
+#
+# Headers start with '=', '==', '===', '====', ... at the beginning of a line
+#
+# Simple text starts with '-' at the beginning of a line.
+#    A single '-' at the beginning of a line, followed by nothing:
+#    - if there was simple text before, it creates a line feed (i.e. encloses the text in a paragraph <p> ... </p>)
+#    - if there was no simple text before or a line feed, it creates an empty line (i.e. <p>&amp;nbsp;</p>)
+#
+# !!!Text yellow background!!! in simple text or headers
+# '''''Text mit bold and italics''''' in simple text or headers
+# '''Text with bold chars''' in simple text or headers
+# ''Text with italic chars'' in simple text or headers
+#
+# Comments start with '#' at the beginning of a line. '#' inside text is not recognized as the start of a comment, i.e.. '#' may occur inside of text.
+#
+# Format of the file: UTF-8
+#
+#
+# Contents in CSV-Format - if ';' is part of the field, then enclose that field in "..."
+#
+# ref;type;comment;from;to;operator
+#
+# - ref       == tag 'ref' of route or route_master
+#                250            defines that routes with 'ref'='250' are expected
+#                250|250a|250b  defines that routes with 'ref'='250' or 'ref'='250a' or 'ref'='250b' are expected - independent of whether this is allowed according to PTv1/PTv2
+# - type      == contents of tags 'route' respectively 'route_master'
+# - comment   == can include comments like; Bus, Expressbus, ...  will not be analyzed, but simply be printed out
+#                !Text with yellow background! in comment (surrounded by single !)
+# - from      == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - to        == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - operator  == if there is more than one entry with "ref;type", then "operator" is used to distinguish between same line number in different cities/villages
+#
+
+
+= Overview on '''LACROIX''' Public Transport Lines
+
+-
+- '''!!!This summary is a list of what has been published in open data by Île-de-France Mobilités and found in OSM!!!'''
+-
+- Feel free to modify the list on github
+-
+#
+#ref;type;comment;from;to;operator
+
+== Lines
+30-04;bus;;;;
+30-13;bus;;;;
+30-25;bus;;;;
+30-27;bus;;;;
+30-28;bus;;;;
+30-29;bus;;;;
+30-31;bus;;;;
+30-32;bus;;;;
+30-33;bus;;;;
+30-34;bus;;;;
+30-36;bus;;;;
+30-39;bus;;;;
+30-42;bus;;;;
+CitéVal C;bus;;;;
+CitéVal F;bus;;;;
+CitéVal N;bus;;;;
+CitéVal S;bus;;;;

--- a/FR-IDF-lacroix/settings.sh
+++ b/FR-IDF-lacroix/settings.sh
@@ -1,0 +1,31 @@
+
+#!/bin/bash
+
+#
+# set variales for analysis of network
+#
+
+PREFIX="FR-IDF-lacroix"
+
+OVERPASS_QUERY="http://overpass-api.de/api/interpreter?data=area[wikidata=Q13917][type=boundary];(rel(area)[route~'bus'];rel(br);rel[type='route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r.routes);node(r.routes););out;"
+NETWORK_LONG=""
+NETWORK_SHORT="LACROIX"
+
+ANALYSIS_PAGE=""
+ANALYSIS_TALK=""
+#
+# Routes data is in GitHub only, not in OSM-Wiki
+#
+WIKI_ROUTES_PAGE=""
+
+ANALYSIS_OPTIONS="--check-access --check-bus-stop --check-name --check-osm-separator --check-sequence --check-stop-position --check-version --coloured-sketchline --check-motorway-link --max-error=10 --multiple-ref-type-entries=analyze --positive-notes"
+
+# --language=en
+# --check-bus-stop 
+# --expect-network-short
+# --expect-network-long
+# --expect-network-short-for=
+# --expect-network-long-for=
+# --relaxed-begin-end-for=
+
+    

--- a/FR-IDF-les-cars-bleus/FR-IDF-les-cars-bleus-Routes.txt
+++ b/FR-IDF-les-cars-bleus/FR-IDF-les-cars-bleus-Routes.txt
@@ -1,0 +1,67 @@
+
+#
+# This data is *not* stored in the OSM Wiki but in GitHub 
+#
+# Format: format is like in the OSM Wiki
+#
+# Links: [[...|...]] are interne link like in the OSM Wiki
+#        [... ...] are external links
+#
+# Headers start with '=', '==', '===', '====', ... at the beginning of a line
+#
+# Simple text starts with '-' at the beginning of a line.
+#    A single '-' at the beginning of a line, followed by nothing:
+#    - if there was simple text before, it creates a line feed (i.e. encloses the text in a paragraph <p> ... </p>)
+#    - if there was no simple text before or a line feed, it creates an empty line (i.e. <p>&amp;nbsp;</p>)
+#
+# !!!Text yellow background!!! in simple text or headers
+# '''''Text mit bold and italics''''' in simple text or headers
+# '''Text with bold chars''' in simple text or headers
+# ''Text with italic chars'' in simple text or headers
+#
+# Comments start with '#' at the beginning of a line. '#' inside text is not recognized as the start of a comment, i.e.. '#' may occur inside of text.
+#
+# Format of the file: UTF-8
+#
+#
+# Contents in CSV-Format - if ';' is part of the field, then enclose that field in "..."
+#
+# ref;type;comment;from;to;operator
+#
+# - ref       == tag 'ref' of route or route_master
+#                250            defines that routes with 'ref'='250' are expected
+#                250|250a|250b  defines that routes with 'ref'='250' or 'ref'='250a' or 'ref'='250b' are expected - independent of whether this is allowed according to PTv1/PTv2
+# - type      == contents of tags 'route' respectively 'route_master'
+# - comment   == can include comments like; Bus, Expressbus, ...  will not be analyzed, but simply be printed out
+#                !Text with yellow background! in comment (surrounded by single !)
+# - from      == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - to        == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - operator  == if there is more than one entry with "ref;type", then "operator" is used to distinguish between same line number in different cities/villages
+#
+
+
+= Overview on '''LES CARS BLEUS''' Public Transport Lines
+
+-
+- '''!!!This summary is a list of what has been published in open data by Île-de-France Mobilités and found in OSM!!!'''
+-
+- Feel free to modify the list on github
+-
+#
+#ref;type;comment;from;to;operator
+
+== Lines
+184-001;bus;;;;
+184-003;bus;;;;
+184-004;bus;;;;
+184-005;bus;;;;
+184-006;bus;;;;
+184-008;bus;;;;
+184-013;bus;;;;
+184-014;bus;;;;
+284-001;bus;;;;
+284-002;bus;;;;
+284-003;bus;;;;
+284-004;bus;;;;
+284-006;bus;;;;
+284-007;bus;;;;

--- a/FR-IDF-les-cars-bleus/settings.sh
+++ b/FR-IDF-les-cars-bleus/settings.sh
@@ -1,0 +1,31 @@
+
+#!/bin/bash
+
+#
+# set variales for analysis of network
+#
+
+PREFIX="FR-IDF-les-cars-bleus"
+
+OVERPASS_QUERY="http://overpass-api.de/api/interpreter?data=area[wikidata=Q13917][type=boundary];(rel(area)[route~'bus'];rel(br);rel[type='route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r.routes);node(r.routes););out;"
+NETWORK_LONG=""
+NETWORK_SHORT="LES CARS BLEUS"
+
+ANALYSIS_PAGE=""
+ANALYSIS_TALK=""
+#
+# Routes data is in GitHub only, not in OSM-Wiki
+#
+WIKI_ROUTES_PAGE=""
+
+ANALYSIS_OPTIONS="--check-access --check-bus-stop --check-name --check-osm-separator --check-sequence --check-stop-position --check-version --coloured-sketchline --check-motorway-link --max-error=10 --multiple-ref-type-entries=analyze --positive-notes"
+
+# --language=en
+# --check-bus-stop 
+# --expect-network-short
+# --expect-network-long
+# --expect-network-short-for=
+# --expect-network-long-for=
+# --relaxed-begin-end-for=
+
+    

--- a/FR-IDF-melibus/FR-IDF-melibus-Routes.txt
+++ b/FR-IDF-melibus/FR-IDF-melibus-Routes.txt
@@ -1,0 +1,76 @@
+
+#
+# This data is *not* stored in the OSM Wiki but in GitHub 
+#
+# Format: format is like in the OSM Wiki
+#
+# Links: [[...|...]] are interne link like in the OSM Wiki
+#        [... ...] are external links
+#
+# Headers start with '=', '==', '===', '====', ... at the beginning of a line
+#
+# Simple text starts with '-' at the beginning of a line.
+#    A single '-' at the beginning of a line, followed by nothing:
+#    - if there was simple text before, it creates a line feed (i.e. encloses the text in a paragraph <p> ... </p>)
+#    - if there was no simple text before or a line feed, it creates an empty line (i.e. <p>&amp;nbsp;</p>)
+#
+# !!!Text yellow background!!! in simple text or headers
+# '''''Text mit bold and italics''''' in simple text or headers
+# '''Text with bold chars''' in simple text or headers
+# ''Text with italic chars'' in simple text or headers
+#
+# Comments start with '#' at the beginning of a line. '#' inside text is not recognized as the start of a comment, i.e.. '#' may occur inside of text.
+#
+# Format of the file: UTF-8
+#
+#
+# Contents in CSV-Format - if ';' is part of the field, then enclose that field in "..."
+#
+# ref;type;comment;from;to;operator
+#
+# - ref       == tag 'ref' of route or route_master
+#                250            defines that routes with 'ref'='250' are expected
+#                250|250a|250b  defines that routes with 'ref'='250' or 'ref'='250a' or 'ref'='250b' are expected - independent of whether this is allowed according to PTv1/PTv2
+# - type      == contents of tags 'route' respectively 'route_master'
+# - comment   == can include comments like; Bus, Expressbus, ...  will not be analyzed, but simply be printed out
+#                !Text with yellow background! in comment (surrounded by single !)
+# - from      == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - to        == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - operator  == if there is more than one entry with "ref;type", then "operator" is used to distinguish between same line number in different cities/villages
+#
+
+
+= Overview on '''MELIBUS''' Public Transport Lines
+
+-
+- '''!!!This summary is a list of what has been published in open data by Île-de-France Mobilités and found in OSM!!!'''
+-
+- Feel free to modify the list on github
+-
+#
+#ref;type;comment;from;to;operator
+
+== Lines
+A;bus;;;;
+B;bus;;;;
+C;bus;;;;
+Cd;bus;;;;
+D;bus;;;;
+E;bus;;;;
+F;bus;;;;
+Fd;bus;;;;
+G;bus;;;;
+J;bus;;;;
+Jd;bus;;;;
+K;bus;;;;
+L;bus;;;;
+M;bus;;;;
+N;bus;;;;
+O;bus;;;;
+O SCO;bus;;;;
+S1;bus;;;;
+S2;bus;;;;
+S3;bus;;;;
+S4;bus;;;;
+S5;bus;;;;
+S6;bus;;;;

--- a/FR-IDF-melibus/settings.sh
+++ b/FR-IDF-melibus/settings.sh
@@ -1,0 +1,31 @@
+
+#!/bin/bash
+
+#
+# set variales for analysis of network
+#
+
+PREFIX="FR-IDF-melibus"
+
+OVERPASS_QUERY="http://overpass-api.de/api/interpreter?data=area[wikidata=Q13917][type=boundary];(rel(area)[route~'bus'];rel(br);rel[type='route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r.routes);node(r.routes););out;"
+NETWORK_LONG=""
+NETWORK_SHORT="MELIBUS"
+
+ANALYSIS_PAGE=""
+ANALYSIS_TALK=""
+#
+# Routes data is in GitHub only, not in OSM-Wiki
+#
+WIKI_ROUTES_PAGE=""
+
+ANALYSIS_OPTIONS="--check-access --check-bus-stop --check-name --check-osm-separator --check-sequence --check-stop-position --check-version --coloured-sketchline --check-motorway-link --max-error=10 --multiple-ref-type-entries=analyze --positive-notes"
+
+# --language=en
+# --check-bus-stop 
+# --expect-network-short
+# --expect-network-long
+# --expect-network-short-for=
+# --expect-network-long-for=
+# --relaxed-begin-end-for=
+
+    

--- a/FR-IDF-mobicaps/FR-IDF-mobicaps-Routes.txt
+++ b/FR-IDF-mobicaps/FR-IDF-mobicaps-Routes.txt
@@ -1,0 +1,77 @@
+
+#
+# This data is *not* stored in the OSM Wiki but in GitHub 
+#
+# Format: format is like in the OSM Wiki
+#
+# Links: [[...|...]] are interne link like in the OSM Wiki
+#        [... ...] are external links
+#
+# Headers start with '=', '==', '===', '====', ... at the beginning of a line
+#
+# Simple text starts with '-' at the beginning of a line.
+#    A single '-' at the beginning of a line, followed by nothing:
+#    - if there was simple text before, it creates a line feed (i.e. encloses the text in a paragraph <p> ... </p>)
+#    - if there was no simple text before or a line feed, it creates an empty line (i.e. <p>&amp;nbsp;</p>)
+#
+# !!!Text yellow background!!! in simple text or headers
+# '''''Text mit bold and italics''''' in simple text or headers
+# '''Text with bold chars''' in simple text or headers
+# ''Text with italic chars'' in simple text or headers
+#
+# Comments start with '#' at the beginning of a line. '#' inside text is not recognized as the start of a comment, i.e.. '#' may occur inside of text.
+#
+# Format of the file: UTF-8
+#
+#
+# Contents in CSV-Format - if ';' is part of the field, then enclose that field in "..."
+#
+# ref;type;comment;from;to;operator
+#
+# - ref       == tag 'ref' of route or route_master
+#                250            defines that routes with 'ref'='250' are expected
+#                250|250a|250b  defines that routes with 'ref'='250' or 'ref'='250a' or 'ref'='250b' are expected - independent of whether this is allowed according to PTv1/PTv2
+# - type      == contents of tags 'route' respectively 'route_master'
+# - comment   == can include comments like; Bus, Expressbus, ...  will not be analyzed, but simply be printed out
+#                !Text with yellow background! in comment (surrounded by single !)
+# - from      == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - to        == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - operator  == if there is more than one entry with "ref;type", then "operator" is used to distinguish between same line number in different cities/villages
+#
+
+
+= Overview on '''Mobicaps''' Public Transport Lines
+
+-
+- '''!!!This summary is a list of what has been published in open data by Île-de-France Mobilités and found in OSM!!!'''
+-
+- Feel free to modify the list on github
+-
+#
+#ref;type;comment;from;to;operator
+
+== Lines
+1;bus;;;;
+14;bus;;;;
+15;bus;;;;
+16;bus;;;;
+18;bus;;;;
+19;bus;;;;
+2;bus;;;;
+20;bus;;;;
+21;bus;;;;
+22;bus;;;;
+23;bus;;;;
+3;bus;;;;
+4;bus;;;;
+5;bus;;;;
+6;bus;;;;
+7;bus;;;;
+8;bus;;;;
+9;bus;;;;
+S1;bus;;;;
+S15;bus;;;;
+S2;bus;;;;
+S3;bus;;;;
+S4;bus;;;;
+S9;bus;;;;

--- a/FR-IDF-mobicaps/settings.sh
+++ b/FR-IDF-mobicaps/settings.sh
@@ -1,0 +1,31 @@
+
+#!/bin/bash
+
+#
+# set variales for analysis of network
+#
+
+PREFIX="FR-IDF-mobicaps"
+
+OVERPASS_QUERY="http://overpass-api.de/api/interpreter?data=area[wikidata=Q13917][type=boundary];(rel(area)[route~'bus'];rel(br);rel[type='route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r.routes);node(r.routes););out;"
+NETWORK_LONG=""
+NETWORK_SHORT="Mobicaps"
+
+ANALYSIS_PAGE=""
+ANALYSIS_TALK=""
+#
+# Routes data is in GitHub only, not in OSM-Wiki
+#
+WIKI_ROUTES_PAGE=""
+
+ANALYSIS_OPTIONS="--check-access --check-bus-stop --check-name --check-osm-separator --check-sequence --check-stop-position --check-version --coloured-sketchline --check-motorway-link --max-error=10 --multiple-ref-type-entries=analyze --positive-notes"
+
+# --language=en
+# --check-bus-stop 
+# --expect-network-short
+# --expect-network-long
+# --expect-network-short-for=
+# --expect-network-long-for=
+# --relaxed-begin-end-for=
+
+    

--- a/FR-IDF-noctilien/FR-IDF-noctilien-Routes.txt
+++ b/FR-IDF-noctilien/FR-IDF-noctilien-Routes.txt
@@ -1,0 +1,101 @@
+
+#
+# This data is *not* stored in the OSM Wiki but in GitHub 
+#
+# Format: format is like in the OSM Wiki
+#
+# Links: [[...|...]] are interne link like in the OSM Wiki
+#        [... ...] are external links
+#
+# Headers start with '=', '==', '===', '====', ... at the beginning of a line
+#
+# Simple text starts with '-' at the beginning of a line.
+#    A single '-' at the beginning of a line, followed by nothing:
+#    - if there was simple text before, it creates a line feed (i.e. encloses the text in a paragraph <p> ... </p>)
+#    - if there was no simple text before or a line feed, it creates an empty line (i.e. <p>&amp;nbsp;</p>)
+#
+# !!!Text yellow background!!! in simple text or headers
+# '''''Text mit bold and italics''''' in simple text or headers
+# '''Text with bold chars''' in simple text or headers
+# ''Text with italic chars'' in simple text or headers
+#
+# Comments start with '#' at the beginning of a line. '#' inside text is not recognized as the start of a comment, i.e.. '#' may occur inside of text.
+#
+# Format of the file: UTF-8
+#
+#
+# Contents in CSV-Format - if ';' is part of the field, then enclose that field in "..."
+#
+# ref;type;comment;from;to;operator
+#
+# - ref       == tag 'ref' of route or route_master
+#                250            defines that routes with 'ref'='250' are expected
+#                250|250a|250b  defines that routes with 'ref'='250' or 'ref'='250a' or 'ref'='250b' are expected - independent of whether this is allowed according to PTv1/PTv2
+# - type      == contents of tags 'route' respectively 'route_master'
+# - comment   == can include comments like; Bus, Expressbus, ...  will not be analyzed, but simply be printed out
+#                !Text with yellow background! in comment (surrounded by single !)
+# - from      == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - to        == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - operator  == if there is more than one entry with "ref;type", then "operator" is used to distinguish between same line number in different cities/villages
+#
+
+
+= Overview on '''Noctilien''' Public Transport Lines
+
+-
+- '''!!!This summary is a list of what has been published in open data by Île-de-France Mobilités and found in OSM!!!'''
+-
+- Feel free to modify the list on github
+-
+#
+#ref;type;comment;from;to;operator
+
+== Lines
+N01;bus;;;;
+N02;bus;;;;
+N11;bus;;;;
+N12;bus;;;;
+N122;bus;;;;
+N13;bus;;;;
+N130;bus;;;;
+N131;bus;;;;
+N132;bus;;;;
+N133;bus;;;;
+N134;bus;;;;
+N135;bus;;;;
+N14;bus;;;;
+N140;bus;;;;
+N141;bus;;;;
+N142;bus;;;;
+N143;bus;;;;
+N144;bus;;;;
+N145;bus;;;;
+N15;bus;;;;
+N150;bus;;;;
+N151;bus;;;;
+N152;bus;;;;
+N153;bus;;;;
+N154;bus;;;;
+N16;bus;;;;
+N21;bus;;;;
+N22;bus;;;;
+N23;bus;;;;
+N24;bus;;;;
+N31;bus;;;;
+N32;bus;;;;
+N33;bus;;;;
+N34;bus;;;;
+N35;bus;;;;
+N41;bus;;;;
+N42;bus;;;;
+N43;bus;;;;
+N44;bus;;;;
+N45;bus;;;;
+N51;bus;;;;
+N52;bus;;;;
+N53;bus;;;;
+N61;bus;;;;
+N62;bus;;;;
+N63;bus;;;;
+N66;bus;;;;
+N71;bus;;;;

--- a/FR-IDF-noctilien/settings.sh
+++ b/FR-IDF-noctilien/settings.sh
@@ -1,0 +1,31 @@
+
+#!/bin/bash
+
+#
+# set variales for analysis of network
+#
+
+PREFIX="FR-IDF-noctilien"
+
+OVERPASS_QUERY="http://overpass-api.de/api/interpreter?data=area[wikidata=Q13917][type=boundary];(rel(area)[route~'bus'];rel(br);rel[type='route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r.routes);node(r.routes););out;"
+NETWORK_LONG=""
+NETWORK_SHORT="Noctilien"
+
+ANALYSIS_PAGE=""
+ANALYSIS_TALK=""
+#
+# Routes data is in GitHub only, not in OSM-Wiki
+#
+WIKI_ROUTES_PAGE=""
+
+ANALYSIS_OPTIONS="--check-access --check-bus-stop --check-name --check-osm-separator --check-sequence --check-stop-position --check-version --coloured-sketchline --check-motorway-link --max-error=10 --multiple-ref-type-entries=analyze --positive-notes"
+
+# --language=en
+# --check-bus-stop 
+# --expect-network-short
+# --expect-network-long
+# --expect-network-short-for=
+# --expect-network-long-for=
+# --relaxed-begin-end-for=
+
+    

--- a/FR-IDF-ormont-transport/FR-IDF-ormont-transport-Routes.txt
+++ b/FR-IDF-ormont-transport/FR-IDF-ormont-transport-Routes.txt
@@ -1,0 +1,78 @@
+
+#
+# This data is *not* stored in the OSM Wiki but in GitHub 
+#
+# Format: format is like in the OSM Wiki
+#
+# Links: [[...|...]] are interne link like in the OSM Wiki
+#        [... ...] are external links
+#
+# Headers start with '=', '==', '===', '====', ... at the beginning of a line
+#
+# Simple text starts with '-' at the beginning of a line.
+#    A single '-' at the beginning of a line, followed by nothing:
+#    - if there was simple text before, it creates a line feed (i.e. encloses the text in a paragraph <p> ... </p>)
+#    - if there was no simple text before or a line feed, it creates an empty line (i.e. <p>&amp;nbsp;</p>)
+#
+# !!!Text yellow background!!! in simple text or headers
+# '''''Text mit bold and italics''''' in simple text or headers
+# '''Text with bold chars''' in simple text or headers
+# ''Text with italic chars'' in simple text or headers
+#
+# Comments start with '#' at the beginning of a line. '#' inside text is not recognized as the start of a comment, i.e.. '#' may occur inside of text.
+#
+# Format of the file: UTF-8
+#
+#
+# Contents in CSV-Format - if ';' is part of the field, then enclose that field in "..."
+#
+# ref;type;comment;from;to;operator
+#
+# - ref       == tag 'ref' of route or route_master
+#                250            defines that routes with 'ref'='250' are expected
+#                250|250a|250b  defines that routes with 'ref'='250' or 'ref'='250a' or 'ref'='250b' are expected - independent of whether this is allowed according to PTv1/PTv2
+# - type      == contents of tags 'route' respectively 'route_master'
+# - comment   == can include comments like; Bus, Expressbus, ...  will not be analyzed, but simply be printed out
+#                !Text with yellow background! in comment (surrounded by single !)
+# - from      == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - to        == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - operator  == if there is more than one entry with "ref;type", then "operator" is used to distinguish between same line number in different cities/villages
+#
+
+
+= Overview on '''ORMONT TRANSPORT''' Public Transport Lines
+
+-
+- '''!!!This summary is a list of what has been published in open data by Île-de-France Mobilités and found in OSM!!!'''
+-
+- Feel free to modify the list on github
+-
+#
+#ref;type;comment;from;to;operator
+
+== Lines
+1;bus;;;;
+2;bus;;;;
+3;bus;;;;
+306.04;bus;;;;
+306.12;bus;;;;
+4;bus;;;;
+5;bus;;;;
+6;bus;;;;
+68.01;bus;;;;
+68.01S;bus;;;;
+68.02;bus;;;;
+68.05 A;bus;;;;
+68.05 B;bus;;;;
+68.06;bus;;;;
+68.08;bus;;;;
+68.09;bus;;;;
+68.100;bus;;;;
+68.13;bus;;;;
+68.14;bus;;;;
+68.16;bus;;;;
+913.07;bus;;;;
+913.08;bus;;;;
+913.10;bus;;;;
+913.17;bus;;;;
+913.50;bus;;;;

--- a/FR-IDF-ormont-transport/settings.sh
+++ b/FR-IDF-ormont-transport/settings.sh
@@ -1,0 +1,31 @@
+
+#!/bin/bash
+
+#
+# set variales for analysis of network
+#
+
+PREFIX="FR-IDF-ormont-transport"
+
+OVERPASS_QUERY="http://overpass-api.de/api/interpreter?data=area[wikidata=Q13917][type=boundary];(rel(area)[route~'bus'];rel(br);rel[type='route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r.routes);node(r.routes););out;"
+NETWORK_LONG=""
+NETWORK_SHORT="ORMONT TRANSPORT"
+
+ANALYSIS_PAGE=""
+ANALYSIS_TALK=""
+#
+# Routes data is in GitHub only, not in OSM-Wiki
+#
+WIKI_ROUTES_PAGE=""
+
+ANALYSIS_OPTIONS="--check-access --check-bus-stop --check-name --check-osm-separator --check-sequence --check-stop-position --check-version --coloured-sketchline --check-motorway-link --max-error=10 --multiple-ref-type-entries=analyze --positive-notes"
+
+# --language=en
+# --check-bus-stop 
+# --expect-network-short
+# --expect-network-long
+# --expect-network-short-for=
+# --expect-network-long-for=
+# --relaxed-begin-end-for=
+
+    

--- a/FR-IDF-paladin/FR-IDF-paladin-Routes.txt
+++ b/FR-IDF-paladin/FR-IDF-paladin-Routes.txt
@@ -1,0 +1,68 @@
+
+#
+# This data is *not* stored in the OSM Wiki but in GitHub 
+#
+# Format: format is like in the OSM Wiki
+#
+# Links: [[...|...]] are interne link like in the OSM Wiki
+#        [... ...] are external links
+#
+# Headers start with '=', '==', '===', '====', ... at the beginning of a line
+#
+# Simple text starts with '-' at the beginning of a line.
+#    A single '-' at the beginning of a line, followed by nothing:
+#    - if there was simple text before, it creates a line feed (i.e. encloses the text in a paragraph <p> ... </p>)
+#    - if there was no simple text before or a line feed, it creates an empty line (i.e. <p>&amp;nbsp;</p>)
+#
+# !!!Text yellow background!!! in simple text or headers
+# '''''Text mit bold and italics''''' in simple text or headers
+# '''Text with bold chars''' in simple text or headers
+# ''Text with italic chars'' in simple text or headers
+#
+# Comments start with '#' at the beginning of a line. '#' inside text is not recognized as the start of a comment, i.e.. '#' may occur inside of text.
+#
+# Format of the file: UTF-8
+#
+#
+# Contents in CSV-Format - if ';' is part of the field, then enclose that field in "..."
+#
+# ref;type;comment;from;to;operator
+#
+# - ref       == tag 'ref' of route or route_master
+#                250            defines that routes with 'ref'='250' are expected
+#                250|250a|250b  defines that routes with 'ref'='250' or 'ref'='250a' or 'ref'='250b' are expected - independent of whether this is allowed according to PTv1/PTv2
+# - type      == contents of tags 'route' respectively 'route_master'
+# - comment   == can include comments like; Bus, Expressbus, ...  will not be analyzed, but simply be printed out
+#                !Text with yellow background! in comment (surrounded by single !)
+# - from      == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - to        == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - operator  == if there is more than one entry with "ref;type", then "operator" is used to distinguish between same line number in different cities/villages
+#
+
+
+= Overview on '''Paladin''' Public Transport Lines
+
+-
+- '''!!!This summary is a list of what has been published in open data by Île-de-France Mobilités and found in OSM!!!'''
+-
+- Feel free to modify the list on github
+-
+#
+#ref;type;comment;from;to;operator
+
+== Lines
+1;bus;;;;
+11;bus;;;;
+12;bus;;;;
+14;bus;;;;
+15;bus;;;;
+16;bus;;;;
+17;bus;;;;
+18;bus;;;;
+2;bus;;;;
+3;bus;;;;
+4;bus;;;;
+6;bus;;;;
+7;bus;;;;
+8;bus;;;;
+9;bus;;;;

--- a/FR-IDF-paladin/settings.sh
+++ b/FR-IDF-paladin/settings.sh
@@ -1,0 +1,31 @@
+
+#!/bin/bash
+
+#
+# set variales for analysis of network
+#
+
+PREFIX="FR-IDF-paladin"
+
+OVERPASS_QUERY="http://overpass-api.de/api/interpreter?data=area[wikidata=Q13917][type=boundary];(rel(area)[route~'bus'];rel(br);rel[type='route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r.routes);node(r.routes););out;"
+NETWORK_LONG=""
+NETWORK_SHORT="Paladin"
+
+ANALYSIS_PAGE=""
+ANALYSIS_TALK=""
+#
+# Routes data is in GitHub only, not in OSM-Wiki
+#
+WIKI_ROUTES_PAGE=""
+
+ANALYSIS_OPTIONS="--check-access --check-bus-stop --check-name --check-osm-separator --check-sequence --check-stop-position --check-version --coloured-sketchline --check-motorway-link --max-error=10 --multiple-ref-type-entries=analyze --positive-notes"
+
+# --language=en
+# --check-bus-stop 
+# --expect-network-short
+# --expect-network-long
+# --expect-network-short-for=
+# --expect-network-long-for=
+# --relaxed-begin-end-for=
+
+    

--- a/FR-IDF-parisis/FR-IDF-parisis-Routes.txt
+++ b/FR-IDF-parisis/FR-IDF-parisis-Routes.txt
@@ -1,0 +1,66 @@
+
+#
+# This data is *not* stored in the OSM Wiki but in GitHub 
+#
+# Format: format is like in the OSM Wiki
+#
+# Links: [[...|...]] are interne link like in the OSM Wiki
+#        [... ...] are external links
+#
+# Headers start with '=', '==', '===', '====', ... at the beginning of a line
+#
+# Simple text starts with '-' at the beginning of a line.
+#    A single '-' at the beginning of a line, followed by nothing:
+#    - if there was simple text before, it creates a line feed (i.e. encloses the text in a paragraph <p> ... </p>)
+#    - if there was no simple text before or a line feed, it creates an empty line (i.e. <p>&amp;nbsp;</p>)
+#
+# !!!Text yellow background!!! in simple text or headers
+# '''''Text mit bold and italics''''' in simple text or headers
+# '''Text with bold chars''' in simple text or headers
+# ''Text with italic chars'' in simple text or headers
+#
+# Comments start with '#' at the beginning of a line. '#' inside text is not recognized as the start of a comment, i.e.. '#' may occur inside of text.
+#
+# Format of the file: UTF-8
+#
+#
+# Contents in CSV-Format - if ';' is part of the field, then enclose that field in "..."
+#
+# ref;type;comment;from;to;operator
+#
+# - ref       == tag 'ref' of route or route_master
+#                250            defines that routes with 'ref'='250' are expected
+#                250|250a|250b  defines that routes with 'ref'='250' or 'ref'='250a' or 'ref'='250b' are expected - independent of whether this is allowed according to PTv1/PTv2
+# - type      == contents of tags 'route' respectively 'route_master'
+# - comment   == can include comments like; Bus, Expressbus, ...  will not be analyzed, but simply be printed out
+#                !Text with yellow background! in comment (surrounded by single !)
+# - from      == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - to        == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - operator  == if there is more than one entry with "ref;type", then "operator" is used to distinguish between same line number in different cities/villages
+#
+
+
+= Overview on '''Parisis''' Public Transport Lines
+
+-
+- '''!!!This summary is a list of what has been published in open data by Île-de-France Mobilités and found in OSM!!!'''
+-
+- Feel free to modify the list on github
+-
+#
+#ref;type;comment;from;to;operator
+
+== Lines
+30-05;bus;;;;
+30-07;bus;;;;
+30-09;bus;;;;
+30-10;bus;;;;
+30-12;bus;;;;
+30-18;bus;;;;
+30-21Est;bus;;;;
+30-21Oues;bus;;;;
+30-38;bus;;;;
+30-46;bus;;;;
+30-47;bus;;;;
+30-48;bus;;;;
+30-49;bus;;;;

--- a/FR-IDF-parisis/settings.sh
+++ b/FR-IDF-parisis/settings.sh
@@ -1,0 +1,31 @@
+
+#!/bin/bash
+
+#
+# set variales for analysis of network
+#
+
+PREFIX="FR-IDF-parisis"
+
+OVERPASS_QUERY="http://overpass-api.de/api/interpreter?data=area[wikidata=Q13917][type=boundary];(rel(area)[route~'bus'];rel(br);rel[type='route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r.routes);node(r.routes););out;"
+NETWORK_LONG=""
+NETWORK_SHORT="Parisis"
+
+ANALYSIS_PAGE=""
+ANALYSIS_TALK=""
+#
+# Routes data is in GitHub only, not in OSM-Wiki
+#
+WIKI_ROUTES_PAGE=""
+
+ANALYSIS_OPTIONS="--check-access --check-bus-stop --check-name --check-osm-separator --check-sequence --check-stop-position --check-version --coloured-sketchline --check-motorway-link --max-error=10 --multiple-ref-type-entries=analyze --positive-notes"
+
+# --language=en
+# --check-bus-stop 
+# --expect-network-short
+# --expect-network-long
+# --expect-network-short-for=
+# --expect-network-long-for=
+# --relaxed-begin-end-for=
+
+    

--- a/FR-IDF-pays-crecois/FR-IDF-pays-crecois-Routes.txt
+++ b/FR-IDF-pays-crecois/FR-IDF-pays-crecois-Routes.txt
@@ -1,0 +1,74 @@
+
+#
+# This data is *not* stored in the OSM Wiki but in GitHub 
+#
+# Format: format is like in the OSM Wiki
+#
+# Links: [[...|...]] are interne link like in the OSM Wiki
+#        [... ...] are external links
+#
+# Headers start with '=', '==', '===', '====', ... at the beginning of a line
+#
+# Simple text starts with '-' at the beginning of a line.
+#    A single '-' at the beginning of a line, followed by nothing:
+#    - if there was simple text before, it creates a line feed (i.e. encloses the text in a paragraph <p> ... </p>)
+#    - if there was no simple text before or a line feed, it creates an empty line (i.e. <p>&amp;nbsp;</p>)
+#
+# !!!Text yellow background!!! in simple text or headers
+# '''''Text mit bold and italics''''' in simple text or headers
+# '''Text with bold chars''' in simple text or headers
+# ''Text with italic chars'' in simple text or headers
+#
+# Comments start with '#' at the beginning of a line. '#' inside text is not recognized as the start of a comment, i.e.. '#' may occur inside of text.
+#
+# Format of the file: UTF-8
+#
+#
+# Contents in CSV-Format - if ';' is part of the field, then enclose that field in "..."
+#
+# ref;type;comment;from;to;operator
+#
+# - ref       == tag 'ref' of route or route_master
+#                250            defines that routes with 'ref'='250' are expected
+#                250|250a|250b  defines that routes with 'ref'='250' or 'ref'='250a' or 'ref'='250b' are expected - independent of whether this is allowed according to PTv1/PTv2
+# - type      == contents of tags 'route' respectively 'route_master'
+# - comment   == can include comments like; Bus, Expressbus, ...  will not be analyzed, but simply be printed out
+#                !Text with yellow background! in comment (surrounded by single !)
+# - from      == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - to        == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - operator  == if there is more than one entry with "ref;type", then "operator" is used to distinguish between same line number in different cities/villages
+#
+
+
+= Overview on '''Pays Créçois''' Public Transport Lines
+
+-
+- '''!!!This summary is a list of what has been published in open data by Île-de-France Mobilités and found in OSM!!!'''
+-
+- Feel free to modify the list on github
+-
+#
+#ref;type;comment;from;to;operator
+
+== Lines
+12;bus;;;;
+13A;bus;;;;
+13B;bus;;;;
+18;bus;;;;
+19;bus;;;;
+21;bus;;;;
+21sco;bus;;;;
+4;bus;;;;
+4A;bus;;;;
+4B;bus;;;;
+57;bus;;;;
+58;bus;;;;
+59;bus;;;;
+60;bus;;;;
+7;bus;;;;
+70;bus;;;;
+71;bus;;;;
+73;bus;;;;
+8A;bus;;;;
+8B;bus;;;;
+8C;bus;;;;

--- a/FR-IDF-pays-crecois/settings.sh
+++ b/FR-IDF-pays-crecois/settings.sh
@@ -1,0 +1,31 @@
+
+#!/bin/bash
+
+#
+# set variales for analysis of network
+#
+
+PREFIX="FR-IDF-pays-crecois"
+
+OVERPASS_QUERY="http://overpass-api.de/api/interpreter?data=area[wikidata=Q13917][type=boundary];(rel(area)[route~'bus'];rel(br);rel[type='route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r.routes);node(r.routes););out;"
+NETWORK_LONG=""
+NETWORK_SHORT="Pays Créçois"
+
+ANALYSIS_PAGE=""
+ANALYSIS_TALK=""
+#
+# Routes data is in GitHub only, not in OSM-Wiki
+#
+WIKI_ROUTES_PAGE=""
+
+ANALYSIS_OPTIONS="--check-access --check-bus-stop --check-name --check-osm-separator --check-sequence --check-stop-position --check-version --coloured-sketchline --check-motorway-link --max-error=10 --multiple-ref-type-entries=analyze --positive-notes"
+
+# --language=en
+# --check-bus-stop 
+# --expect-network-short
+# --expect-network-long
+# --expect-network-short-for=
+# --expect-network-long-for=
+# --relaxed-begin-end-for=
+
+    

--- a/FR-IDF-pays-de-l-ourcq/FR-IDF-pays-de-l-ourcq-Routes.txt
+++ b/FR-IDF-pays-de-l-ourcq/FR-IDF-pays-de-l-ourcq-Routes.txt
@@ -1,0 +1,70 @@
+
+#
+# This data is *not* stored in the OSM Wiki but in GitHub 
+#
+# Format: format is like in the OSM Wiki
+#
+# Links: [[...|...]] are interne link like in the OSM Wiki
+#        [... ...] are external links
+#
+# Headers start with '=', '==', '===', '====', ... at the beginning of a line
+#
+# Simple text starts with '-' at the beginning of a line.
+#    A single '-' at the beginning of a line, followed by nothing:
+#    - if there was simple text before, it creates a line feed (i.e. encloses the text in a paragraph <p> ... </p>)
+#    - if there was no simple text before or a line feed, it creates an empty line (i.e. <p>&amp;nbsp;</p>)
+#
+# !!!Text yellow background!!! in simple text or headers
+# '''''Text mit bold and italics''''' in simple text or headers
+# '''Text with bold chars''' in simple text or headers
+# ''Text with italic chars'' in simple text or headers
+#
+# Comments start with '#' at the beginning of a line. '#' inside text is not recognized as the start of a comment, i.e.. '#' may occur inside of text.
+#
+# Format of the file: UTF-8
+#
+#
+# Contents in CSV-Format - if ';' is part of the field, then enclose that field in "..."
+#
+# ref;type;comment;from;to;operator
+#
+# - ref       == tag 'ref' of route or route_master
+#                250            defines that routes with 'ref'='250' are expected
+#                250|250a|250b  defines that routes with 'ref'='250' or 'ref'='250a' or 'ref'='250b' are expected - independent of whether this is allowed according to PTv1/PTv2
+# - type      == contents of tags 'route' respectively 'route_master'
+# - comment   == can include comments like; Bus, Expressbus, ...  will not be analyzed, but simply be printed out
+#                !Text with yellow background! in comment (surrounded by single !)
+# - from      == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - to        == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - operator  == if there is more than one entry with "ref;type", then "operator" is used to distinguish between same line number in different cities/villages
+#
+
+
+= Overview on '''Pays de l'Ourcq''' Public Transport Lines
+
+-
+- '''!!!This summary is a list of what has been published in open data by Île-de-France Mobilités and found in OSM!!!'''
+-
+- Feel free to modify the list on github
+-
+#
+#ref;type;comment;from;to;operator
+
+== Lines
+10;bus;;;;
+11;bus;;;;
+22;bus;;;;
+23;bus;;;;
+40;bus;;;;
+41;bus;;;;
+42;bus;;;;
+46;bus;;;;
+47;bus;;;;
+50;bus;;;;
+52;bus;;;;
+53;bus;;;;
+54;bus;;;;
+54bis;bus;;;;
+61;bus;;;;
+63;bus;;;;
+65;bus;;;;

--- a/FR-IDF-pays-de-l-ourcq/settings.sh
+++ b/FR-IDF-pays-de-l-ourcq/settings.sh
@@ -1,0 +1,31 @@
+
+#!/bin/bash
+
+#
+# set variales for analysis of network
+#
+
+PREFIX="FR-IDF-pays-de-l-ourcq"
+
+OVERPASS_QUERY="http://overpass-api.de/api/interpreter?data=area[wikidata=Q13917][type=boundary];(rel(area)[route~'bus'];rel(br);rel[type='route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r.routes);node(r.routes););out;"
+NETWORK_LONG=""
+NETWORK_SHORT="Pays de l'Ourcq"
+
+ANALYSIS_PAGE=""
+ANALYSIS_TALK=""
+#
+# Routes data is in GitHub only, not in OSM-Wiki
+#
+WIKI_ROUTES_PAGE=""
+
+ANALYSIS_OPTIONS="--check-access --check-bus-stop --check-name --check-osm-separator --check-sequence --check-stop-position --check-version --coloured-sketchline --check-motorway-link --max-error=10 --multiple-ref-type-entries=analyze --positive-notes"
+
+# --language=en
+# --check-bus-stop 
+# --expect-network-short
+# --expect-network-long
+# --expect-network-short-for=
+# --expect-network-long-for=
+# --relaxed-begin-end-for=
+
+    

--- a/FR-IDF-pays-de-meaux/FR-IDF-pays-de-meaux-Routes.txt
+++ b/FR-IDF-pays-de-meaux/FR-IDF-pays-de-meaux-Routes.txt
@@ -1,0 +1,74 @@
+
+#
+# This data is *not* stored in the OSM Wiki but in GitHub 
+#
+# Format: format is like in the OSM Wiki
+#
+# Links: [[...|...]] are interne link like in the OSM Wiki
+#        [... ...] are external links
+#
+# Headers start with '=', '==', '===', '====', ... at the beginning of a line
+#
+# Simple text starts with '-' at the beginning of a line.
+#    A single '-' at the beginning of a line, followed by nothing:
+#    - if there was simple text before, it creates a line feed (i.e. encloses the text in a paragraph <p> ... </p>)
+#    - if there was no simple text before or a line feed, it creates an empty line (i.e. <p>&amp;nbsp;</p>)
+#
+# !!!Text yellow background!!! in simple text or headers
+# '''''Text mit bold and italics''''' in simple text or headers
+# '''Text with bold chars''' in simple text or headers
+# ''Text with italic chars'' in simple text or headers
+#
+# Comments start with '#' at the beginning of a line. '#' inside text is not recognized as the start of a comment, i.e.. '#' may occur inside of text.
+#
+# Format of the file: UTF-8
+#
+#
+# Contents in CSV-Format - if ';' is part of the field, then enclose that field in "..."
+#
+# ref;type;comment;from;to;operator
+#
+# - ref       == tag 'ref' of route or route_master
+#                250            defines that routes with 'ref'='250' are expected
+#                250|250a|250b  defines that routes with 'ref'='250' or 'ref'='250a' or 'ref'='250b' are expected - independent of whether this is allowed according to PTv1/PTv2
+# - type      == contents of tags 'route' respectively 'route_master'
+# - comment   == can include comments like; Bus, Expressbus, ...  will not be analyzed, but simply be printed out
+#                !Text with yellow background! in comment (surrounded by single !)
+# - from      == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - to        == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - operator  == if there is more than one entry with "ref;type", then "operator" is used to distinguish between same line number in different cities/villages
+#
+
+
+= Overview on '''Pays de Meaux''' Public Transport Lines
+
+-
+- '''!!!This summary is a list of what has been published in open data by Île-de-France Mobilités and found in OSM!!!'''
+-
+- Feel free to modify the list on github
+-
+#
+#ref;type;comment;from;to;operator
+
+== Lines
+A;bus;;;;
+B;bus;;;;
+C;bus;;;;
+D;bus;;;;
+E;bus;;;;
+Es;bus;;;;
+F;bus;;;;
+G;bus;;;;
+I;bus;;;;
+J;bus;;;;
+Js;bus;;;;
+K;bus;;;;
+Ks;bus;;;;
+L;bus;;;;
+Ls;bus;;;;
+M;bus;;;;
+N;bus;;;;
+Ns;bus;;;;
+O;bus;;;;
+Os;bus;;;;
+Qs;bus;;;;

--- a/FR-IDF-pays-de-meaux/settings.sh
+++ b/FR-IDF-pays-de-meaux/settings.sh
@@ -1,0 +1,31 @@
+
+#!/bin/bash
+
+#
+# set variales for analysis of network
+#
+
+PREFIX="FR-IDF-pays-de-meaux"
+
+OVERPASS_QUERY="http://overpass-api.de/api/interpreter?data=area[wikidata=Q13917][type=boundary];(rel(area)[route~'bus'];rel(br);rel[type='route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r.routes);node(r.routes););out;"
+NETWORK_LONG=""
+NETWORK_SHORT="Pays de Meaux"
+
+ANALYSIS_PAGE=""
+ANALYSIS_TALK=""
+#
+# Routes data is in GitHub only, not in OSM-Wiki
+#
+WIKI_ROUTES_PAGE=""
+
+ANALYSIS_OPTIONS="--check-access --check-bus-stop --check-name --check-osm-separator --check-sequence --check-stop-position --check-version --coloured-sketchline --check-motorway-link --max-error=10 --multiple-ref-type-entries=analyze --positive-notes"
+
+# --language=en
+# --check-bus-stop 
+# --expect-network-short
+# --expect-network-long
+# --expect-network-short-for=
+# --expect-network-long-for=
+# --relaxed-begin-end-for=
+
+    

--- a/FR-IDF-pays-fertois/FR-IDF-pays-fertois-Routes.txt
+++ b/FR-IDF-pays-fertois/FR-IDF-pays-fertois-Routes.txt
@@ -1,0 +1,71 @@
+
+#
+# This data is *not* stored in the OSM Wiki but in GitHub 
+#
+# Format: format is like in the OSM Wiki
+#
+# Links: [[...|...]] are interne link like in the OSM Wiki
+#        [... ...] are external links
+#
+# Headers start with '=', '==', '===', '====', ... at the beginning of a line
+#
+# Simple text starts with '-' at the beginning of a line.
+#    A single '-' at the beginning of a line, followed by nothing:
+#    - if there was simple text before, it creates a line feed (i.e. encloses the text in a paragraph <p> ... </p>)
+#    - if there was no simple text before or a line feed, it creates an empty line (i.e. <p>&amp;nbsp;</p>)
+#
+# !!!Text yellow background!!! in simple text or headers
+# '''''Text mit bold and italics''''' in simple text or headers
+# '''Text with bold chars''' in simple text or headers
+# ''Text with italic chars'' in simple text or headers
+#
+# Comments start with '#' at the beginning of a line. '#' inside text is not recognized as the start of a comment, i.e.. '#' may occur inside of text.
+#
+# Format of the file: UTF-8
+#
+#
+# Contents in CSV-Format - if ';' is part of the field, then enclose that field in "..."
+#
+# ref;type;comment;from;to;operator
+#
+# - ref       == tag 'ref' of route or route_master
+#                250            defines that routes with 'ref'='250' are expected
+#                250|250a|250b  defines that routes with 'ref'='250' or 'ref'='250a' or 'ref'='250b' are expected - independent of whether this is allowed according to PTv1/PTv2
+# - type      == contents of tags 'route' respectively 'route_master'
+# - comment   == can include comments like; Bus, Expressbus, ...  will not be analyzed, but simply be printed out
+#                !Text with yellow background! in comment (surrounded by single !)
+# - from      == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - to        == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - operator  == if there is more than one entry with "ref;type", then "operator" is used to distinguish between same line number in different cities/villages
+#
+
+
+= Overview on '''Pays Fertois''' Public Transport Lines
+
+-
+- '''!!!This summary is a list of what has been published in open data by Île-de-France Mobilités and found in OSM!!!'''
+-
+- Feel free to modify the list on github
+-
+#
+#ref;type;comment;from;to;operator
+
+== Lines
+31;bus;;;;
+31sco;bus;;;;
+32;bus;;;;
+32sco;bus;;;;
+33;bus;;;;
+34;bus;;;;
+34sco;bus;;;;
+35;bus;;;;
+40;bus;;;;
+41A;bus;;;;
+41B;bus;;;;
+48;bus;;;;
+49A;bus;;;;
+49B;bus;;;;
+56;bus;;;;
+56sco;bus;;;;
+62;bus;;;;
+67;bus;;;;

--- a/FR-IDF-pays-fertois/settings.sh
+++ b/FR-IDF-pays-fertois/settings.sh
@@ -1,0 +1,31 @@
+
+#!/bin/bash
+
+#
+# set variales for analysis of network
+#
+
+PREFIX="FR-IDF-pays-fertois"
+
+OVERPASS_QUERY="http://overpass-api.de/api/interpreter?data=area[wikidata=Q13917][type=boundary];(rel(area)[route~'bus'];rel(br);rel[type='route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r.routes);node(r.routes););out;"
+NETWORK_LONG=""
+NETWORK_SHORT="Pays Fertois"
+
+ANALYSIS_PAGE=""
+ANALYSIS_TALK=""
+#
+# Routes data is in GitHub only, not in OSM-Wiki
+#
+WIKI_ROUTES_PAGE=""
+
+ANALYSIS_OPTIONS="--check-access --check-bus-stop --check-name --check-osm-separator --check-sequence --check-stop-position --check-version --coloured-sketchline --check-motorway-link --max-error=10 --multiple-ref-type-entries=analyze --positive-notes"
+
+# --language=en
+# --check-bus-stop 
+# --expect-network-short
+# --expect-network-long
+# --expect-network-short-for=
+# --expect-network-long-for=
+# --relaxed-begin-end-for=
+
+    

--- a/FR-IDF-phebus/FR-IDF-phebus-Routes.txt
+++ b/FR-IDF-phebus/FR-IDF-phebus-Routes.txt
@@ -1,0 +1,104 @@
+
+#
+# This data is *not* stored in the OSM Wiki but in GitHub 
+#
+# Format: format is like in the OSM Wiki
+#
+# Links: [[...|...]] are interne link like in the OSM Wiki
+#        [... ...] are external links
+#
+# Headers start with '=', '==', '===', '====', ... at the beginning of a line
+#
+# Simple text starts with '-' at the beginning of a line.
+#    A single '-' at the beginning of a line, followed by nothing:
+#    - if there was simple text before, it creates a line feed (i.e. encloses the text in a paragraph <p> ... </p>)
+#    - if there was no simple text before or a line feed, it creates an empty line (i.e. <p>&amp;nbsp;</p>)
+#
+# !!!Text yellow background!!! in simple text or headers
+# '''''Text mit bold and italics''''' in simple text or headers
+# '''Text with bold chars''' in simple text or headers
+# ''Text with italic chars'' in simple text or headers
+#
+# Comments start with '#' at the beginning of a line. '#' inside text is not recognized as the start of a comment, i.e.. '#' may occur inside of text.
+#
+# Format of the file: UTF-8
+#
+#
+# Contents in CSV-Format - if ';' is part of the field, then enclose that field in "..."
+#
+# ref;type;comment;from;to;operator
+#
+# - ref       == tag 'ref' of route or route_master
+#                250            defines that routes with 'ref'='250' are expected
+#                250|250a|250b  defines that routes with 'ref'='250' or 'ref'='250a' or 'ref'='250b' are expected - independent of whether this is allowed according to PTv1/PTv2
+# - type      == contents of tags 'route' respectively 'route_master'
+# - comment   == can include comments like; Bus, Expressbus, ...  will not be analyzed, but simply be printed out
+#                !Text with yellow background! in comment (surrounded by single !)
+# - from      == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - to        == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - operator  == if there is more than one entry with "ref;type", then "operator" is used to distinguish between same line number in different cities/villages
+#
+
+
+= Overview on '''Phébus''' Public Transport Lines
+
+-
+- '''!!!This summary is a list of what has been published in open data by Île-de-France Mobilités and found in OSM!!!'''
+-
+- Feel free to modify the list on github
+-
+#
+#ref;type;comment;from;to;operator
+
+== Lines
+22;bus;;;;
+23;bus;;;;
+24;bus;;;;
+31;bus;;;;
+32;bus;;;;
+33;bus;;;;
+34;bus;;;;
+35;bus;;;;
+36;bus;;;;
+40;bus;;;;
+42;bus;;;;
+45;bus;;;;
+52;bus;;;;
+53;bus;;;;
+54;bus;;;;
+60;bus;;;;
+A;bus;;;;
+ARC;bus;;;;
+B;bus;;;;
+BAK;bus;;;;
+C;bus;;;;
+D;bus;;;;
+E;bus;;;;
+F;bus;;;;
+G;bus;;;;
+GHP;bus;;;;
+H;bus;;;;
+Hex;bus;;;;
+I;bus;;;;
+ILAB;bus;;;;
+ILFA;bus;;;;
+ISDM;bus;;;;
+J;bus;;;;
+JLB;bus;;;;
+K;bus;;;;
+L;bus;;;;
+LLFA;bus;;;;
+M;bus;;;;
+N;bus;;;;
+Nuit 1;bus;;;;
+Nuit 3;bus;;;;
+O;bus;;;;
+P;bus;;;;
+R;bus;;;;
+S;bus;;;;
+Tex;bus;;;;
+U;bus;;;;
+V;bus;;;;
+W;bus;;;;
+X;bus;;;;
+Z;bus;;;;

--- a/FR-IDF-phebus/settings.sh
+++ b/FR-IDF-phebus/settings.sh
@@ -1,0 +1,31 @@
+
+#!/bin/bash
+
+#
+# set variales for analysis of network
+#
+
+PREFIX="FR-IDF-phebus"
+
+OVERPASS_QUERY="http://overpass-api.de/api/interpreter?data=area[wikidata=Q13917][type=boundary];(rel(area)[route~'bus'];rel(br);rel[type='route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r.routes);node(r.routes););out;"
+NETWORK_LONG=""
+NETWORK_SHORT="Phébus"
+
+ANALYSIS_PAGE=""
+ANALYSIS_TALK=""
+#
+# Routes data is in GitHub only, not in OSM-Wiki
+#
+WIKI_ROUTES_PAGE=""
+
+ANALYSIS_OPTIONS="--check-access --check-bus-stop --check-name --check-osm-separator --check-sequence --check-stop-position --check-version --coloured-sketchline --check-motorway-link --max-error=10 --multiple-ref-type-entries=analyze --positive-notes"
+
+# --language=en
+# --check-bus-stop 
+# --expect-network-short
+# --expect-network-long
+# --expect-network-short-for=
+# --expect-network-long-for=
+# --relaxed-begin-end-for=
+
+    

--- a/FR-IDF-poissy-aval-deux-rives-de-seine/FR-IDF-poissy-aval-deux-rives-de-seine-Routes.txt
+++ b/FR-IDF-poissy-aval-deux-rives-de-seine/FR-IDF-poissy-aval-deux-rives-de-seine-Routes.txt
@@ -1,0 +1,68 @@
+
+#
+# This data is *not* stored in the OSM Wiki but in GitHub 
+#
+# Format: format is like in the OSM Wiki
+#
+# Links: [[...|...]] are interne link like in the OSM Wiki
+#        [... ...] are external links
+#
+# Headers start with '=', '==', '===', '====', ... at the beginning of a line
+#
+# Simple text starts with '-' at the beginning of a line.
+#    A single '-' at the beginning of a line, followed by nothing:
+#    - if there was simple text before, it creates a line feed (i.e. encloses the text in a paragraph <p> ... </p>)
+#    - if there was no simple text before or a line feed, it creates an empty line (i.e. <p>&amp;nbsp;</p>)
+#
+# !!!Text yellow background!!! in simple text or headers
+# '''''Text mit bold and italics''''' in simple text or headers
+# '''Text with bold chars''' in simple text or headers
+# ''Text with italic chars'' in simple text or headers
+#
+# Comments start with '#' at the beginning of a line. '#' inside text is not recognized as the start of a comment, i.e.. '#' may occur inside of text.
+#
+# Format of the file: UTF-8
+#
+#
+# Contents in CSV-Format - if ';' is part of the field, then enclose that field in "..."
+#
+# ref;type;comment;from;to;operator
+#
+# - ref       == tag 'ref' of route or route_master
+#                250            defines that routes with 'ref'='250' are expected
+#                250|250a|250b  defines that routes with 'ref'='250' or 'ref'='250a' or 'ref'='250b' are expected - independent of whether this is allowed according to PTv1/PTv2
+# - type      == contents of tags 'route' respectively 'route_master'
+# - comment   == can include comments like; Bus, Expressbus, ...  will not be analyzed, but simply be printed out
+#                !Text with yellow background! in comment (surrounded by single !)
+# - from      == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - to        == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - operator  == if there is more than one entry with "ref;type", then "operator" is used to distinguish between same line number in different cities/villages
+#
+
+
+= Overview on '''Poissy Aval - Deux Rives de Seine''' Public Transport Lines
+
+-
+- '''!!!This summary is a list of what has been published in open data by Île-de-France Mobilités and found in OSM!!!'''
+-
+- Feel free to modify the list on github
+-
+#
+#ref;type;comment;from;to;operator
+
+== Lines
+1;bus;;;;
+12;bus;;;;
+13;bus;;;;
+2;bus;;;;
+22;bus;;;;
+26;bus;;;;
+29;bus;;;;
+3;bus;;;;
+30;bus;;;;
+31;bus;;;;
+32;bus;;;;
+33;bus;;;;
+35;bus;;;;
+37;bus;;;;
+39;bus;;;;

--- a/FR-IDF-poissy-aval-deux-rives-de-seine/settings.sh
+++ b/FR-IDF-poissy-aval-deux-rives-de-seine/settings.sh
@@ -1,0 +1,31 @@
+
+#!/bin/bash
+
+#
+# set variales for analysis of network
+#
+
+PREFIX="FR-IDF-poissy-aval-deux-rives-de-seine"
+
+OVERPASS_QUERY="http://overpass-api.de/api/interpreter?data=area[wikidata=Q13917][type=boundary];(rel(area)[route~'bus'];rel(br);rel[type='route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r.routes);node(r.routes););out;"
+NETWORK_LONG=""
+NETWORK_SHORT="Poissy Aval - Deux Rives de Seine"
+
+ANALYSIS_PAGE=""
+ANALYSIS_TALK=""
+#
+# Routes data is in GitHub only, not in OSM-Wiki
+#
+WIKI_ROUTES_PAGE=""
+
+ANALYSIS_OPTIONS="--check-access --check-bus-stop --check-name --check-osm-separator --check-sequence --check-stop-position --check-version --coloured-sketchline --check-motorway-link --max-error=10 --multiple-ref-type-entries=analyze --positive-notes"
+
+# --language=en
+# --check-bus-stop 
+# --expect-network-short
+# --expect-network-long
+# --expect-network-short-for=
+# --expect-network-long-for=
+# --relaxed-begin-end-for=
+
+    

--- a/FR-IDF-procars/FR-IDF-procars-Routes.txt
+++ b/FR-IDF-procars/FR-IDF-procars-Routes.txt
@@ -1,0 +1,76 @@
+
+#
+# This data is *not* stored in the OSM Wiki but in GitHub 
+#
+# Format: format is like in the OSM Wiki
+#
+# Links: [[...|...]] are interne link like in the OSM Wiki
+#        [... ...] are external links
+#
+# Headers start with '=', '==', '===', '====', ... at the beginning of a line
+#
+# Simple text starts with '-' at the beginning of a line.
+#    A single '-' at the beginning of a line, followed by nothing:
+#    - if there was simple text before, it creates a line feed (i.e. encloses the text in a paragraph <p> ... </p>)
+#    - if there was no simple text before or a line feed, it creates an empty line (i.e. <p>&amp;nbsp;</p>)
+#
+# !!!Text yellow background!!! in simple text or headers
+# '''''Text mit bold and italics''''' in simple text or headers
+# '''Text with bold chars''' in simple text or headers
+# ''Text with italic chars'' in simple text or headers
+#
+# Comments start with '#' at the beginning of a line. '#' inside text is not recognized as the start of a comment, i.e.. '#' may occur inside of text.
+#
+# Format of the file: UTF-8
+#
+#
+# Contents in CSV-Format - if ';' is part of the field, then enclose that field in "..."
+#
+# ref;type;comment;from;to;operator
+#
+# - ref       == tag 'ref' of route or route_master
+#                250            defines that routes with 'ref'='250' are expected
+#                250|250a|250b  defines that routes with 'ref'='250' or 'ref'='250a' or 'ref'='250b' are expected - independent of whether this is allowed according to PTv1/PTv2
+# - type      == contents of tags 'route' respectively 'route_master'
+# - comment   == can include comments like; Bus, Expressbus, ...  will not be analyzed, but simply be printed out
+#                !Text with yellow background! in comment (surrounded by single !)
+# - from      == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - to        == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - operator  == if there is more than one entry with "ref;type", then "operator" is used to distinguish between same line number in different cities/villages
+#
+
+
+= Overview on '''PROCARS''' Public Transport Lines
+
+-
+- '''!!!This summary is a list of what has been published in open data by Île-de-France Mobilités and found in OSM!!!'''
+-
+- Feel free to modify the list on github
+-
+#
+#ref;type;comment;from;to;operator
+
+== Lines
+01;bus;;;;
+02;bus;;;;
+03;bus;;;;
+05;bus;;;;
+06;bus;;;;
+08;bus;;;;
+10;bus;;;;
+11;bus;;;;
+12;bus;;;;
+13;bus;;;;
+14;bus;;;;
+16;bus;;;;
+17;bus;;;;
+46;bus;;;;
+NANGIBUSR;bus;;;;
+NANGIBUSV;bus;;;;
+PROBUS A;bus;;;;
+PROBUS B;bus;;;;
+PROBUS C;bus;;;;
+PROBUS D;bus;;;;
+PROBUS E;bus;;;;
+PROBUSsco;bus;;;;
+VILLEFERM;bus;;;;

--- a/FR-IDF-procars/settings.sh
+++ b/FR-IDF-procars/settings.sh
@@ -1,0 +1,31 @@
+
+#!/bin/bash
+
+#
+# set variales for analysis of network
+#
+
+PREFIX="FR-IDF-procars"
+
+OVERPASS_QUERY="http://overpass-api.de/api/interpreter?data=area[wikidata=Q13917][type=boundary];(rel(area)[route~'bus'];rel(br);rel[type='route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r.routes);node(r.routes););out;"
+NETWORK_LONG=""
+NETWORK_SHORT="PROCARS"
+
+ANALYSIS_PAGE=""
+ANALYSIS_TALK=""
+#
+# Routes data is in GitHub only, not in OSM-Wiki
+#
+WIKI_ROUTES_PAGE=""
+
+ANALYSIS_OPTIONS="--check-access --check-bus-stop --check-name --check-osm-separator --check-sequence --check-stop-position --check-version --coloured-sketchline --check-motorway-link --max-error=10 --multiple-ref-type-entries=analyze --positive-notes"
+
+# --language=en
+# --check-bus-stop 
+# --expect-network-short
+# --expect-network-long
+# --expect-network-short-for=
+# --expect-network-long-for=
+# --relaxed-begin-end-for=
+
+    

--- a/FR-IDF-r-bus/FR-IDF-r-bus-Routes.txt
+++ b/FR-IDF-r-bus/FR-IDF-r-bus-Routes.txt
@@ -1,0 +1,69 @@
+
+#
+# This data is *not* stored in the OSM Wiki but in GitHub 
+#
+# Format: format is like in the OSM Wiki
+#
+# Links: [[...|...]] are interne link like in the OSM Wiki
+#        [... ...] are external links
+#
+# Headers start with '=', '==', '===', '====', ... at the beginning of a line
+#
+# Simple text starts with '-' at the beginning of a line.
+#    A single '-' at the beginning of a line, followed by nothing:
+#    - if there was simple text before, it creates a line feed (i.e. encloses the text in a paragraph <p> ... </p>)
+#    - if there was no simple text before or a line feed, it creates an empty line (i.e. <p>&amp;nbsp;</p>)
+#
+# !!!Text yellow background!!! in simple text or headers
+# '''''Text mit bold and italics''''' in simple text or headers
+# '''Text with bold chars''' in simple text or headers
+# ''Text with italic chars'' in simple text or headers
+#
+# Comments start with '#' at the beginning of a line. '#' inside text is not recognized as the start of a comment, i.e.. '#' may occur inside of text.
+#
+# Format of the file: UTF-8
+#
+#
+# Contents in CSV-Format - if ';' is part of the field, then enclose that field in "..."
+#
+# ref;type;comment;from;to;operator
+#
+# - ref       == tag 'ref' of route or route_master
+#                250            defines that routes with 'ref'='250' are expected
+#                250|250a|250b  defines that routes with 'ref'='250' or 'ref'='250a' or 'ref'='250b' are expected - independent of whether this is allowed according to PTv1/PTv2
+# - type      == contents of tags 'route' respectively 'route_master'
+# - comment   == can include comments like; Bus, Expressbus, ...  will not be analyzed, but simply be printed out
+#                !Text with yellow background! in comment (surrounded by single !)
+# - from      == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - to        == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - operator  == if there is more than one entry with "ref;type", then "operator" is used to distinguish between same line number in different cities/villages
+#
+
+
+= Overview on '''R'bus''' Public Transport Lines
+
+-
+- '''!!!This summary is a list of what has been published in open data by Île-de-France Mobilités and found in OSM!!!'''
+-
+- Feel free to modify the list on github
+-
+#
+#ref;type;comment;from;to;operator
+
+== Lines
+1;bus;;;;
+17;bus;;;;
+18;bus;;;;
+2;bus;;;;
+3;bus;;;;
+34;bus;;;;
+4;bus;;;;
+45;bus;;;;
+5;bus;;;;
+501 Sco;bus;;;;
+502 Sco;bus;;;;
+503 Sco;bus;;;;
+6;bus;;;;
+7;bus;;;;
+8;bus;;;;
+9;bus;;;;

--- a/FR-IDF-r-bus/settings.sh
+++ b/FR-IDF-r-bus/settings.sh
@@ -1,0 +1,31 @@
+
+#!/bin/bash
+
+#
+# set variales for analysis of network
+#
+
+PREFIX="FR-IDF-r-bus"
+
+OVERPASS_QUERY="http://overpass-api.de/api/interpreter?data=area[wikidata=Q13917][type=boundary];(rel(area)[route~'bus'];rel(br);rel[type='route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r.routes);node(r.routes););out;"
+NETWORK_LONG=""
+NETWORK_SHORT="R'bus"
+
+ANALYSIS_PAGE=""
+ANALYSIS_TALK=""
+#
+# Routes data is in GitHub only, not in OSM-Wiki
+#
+WIKI_ROUTES_PAGE=""
+
+ANALYSIS_OPTIONS="--check-access --check-bus-stop --check-name --check-osm-separator --check-sequence --check-stop-position --check-version --coloured-sketchline --check-motorway-link --max-error=10 --multiple-ref-type-entries=analyze --positive-notes"
+
+# --language=en
+# --check-bus-stop 
+# --expect-network-short
+# --expect-network-long
+# --expect-network-short-for=
+# --expect-network-long-for=
+# --relaxed-begin-end-for=
+
+    

--- a/FR-IDF-rambouillet-interurbain/FR-IDF-rambouillet-interurbain-Routes.txt
+++ b/FR-IDF-rambouillet-interurbain/FR-IDF-rambouillet-interurbain-Routes.txt
@@ -1,0 +1,74 @@
+
+#
+# This data is *not* stored in the OSM Wiki but in GitHub 
+#
+# Format: format is like in the OSM Wiki
+#
+# Links: [[...|...]] are interne link like in the OSM Wiki
+#        [... ...] are external links
+#
+# Headers start with '=', '==', '===', '====', ... at the beginning of a line
+#
+# Simple text starts with '-' at the beginning of a line.
+#    A single '-' at the beginning of a line, followed by nothing:
+#    - if there was simple text before, it creates a line feed (i.e. encloses the text in a paragraph <p> ... </p>)
+#    - if there was no simple text before or a line feed, it creates an empty line (i.e. <p>&amp;nbsp;</p>)
+#
+# !!!Text yellow background!!! in simple text or headers
+# '''''Text mit bold and italics''''' in simple text or headers
+# '''Text with bold chars''' in simple text or headers
+# ''Text with italic chars'' in simple text or headers
+#
+# Comments start with '#' at the beginning of a line. '#' inside text is not recognized as the start of a comment, i.e.. '#' may occur inside of text.
+#
+# Format of the file: UTF-8
+#
+#
+# Contents in CSV-Format - if ';' is part of the field, then enclose that field in "..."
+#
+# ref;type;comment;from;to;operator
+#
+# - ref       == tag 'ref' of route or route_master
+#                250            defines that routes with 'ref'='250' are expected
+#                250|250a|250b  defines that routes with 'ref'='250' or 'ref'='250a' or 'ref'='250b' are expected - independent of whether this is allowed according to PTv1/PTv2
+# - type      == contents of tags 'route' respectively 'route_master'
+# - comment   == can include comments like; Bus, Expressbus, ...  will not be analyzed, but simply be printed out
+#                !Text with yellow background! in comment (surrounded by single !)
+# - from      == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - to        == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - operator  == if there is more than one entry with "ref;type", then "operator" is used to distinguish between same line number in different cities/villages
+#
+
+
+= Overview on '''Rambouillet Interurbain''' Public Transport Lines
+
+-
+- '''!!!This summary is a list of what has been published in open data by Île-de-France Mobilités and found in OSM!!!'''
+-
+- Feel free to modify the list on github
+-
+#
+#ref;type;comment;from;to;operator
+
+== Lines
+01;bus;;;;
+03;bus;;;;
+04;bus;;;;
+05;bus;;;;
+08;bus;;;;
+10;bus;;;;
+11;bus;;;;
+12;bus;;;;
+19;bus;;;;
+20;bus;;;;
+23;bus;;;;
+24;bus;;;;
+25;bus;;;;
+26;bus;;;;
+29;bus;;;;
+30;bus;;;;
+39;bus;;;;
+49;bus;;;;
+59;bus;;;;
+79;bus;;;;
+89;bus;;;;

--- a/FR-IDF-rambouillet-interurbain/settings.sh
+++ b/FR-IDF-rambouillet-interurbain/settings.sh
@@ -1,0 +1,31 @@
+
+#!/bin/bash
+
+#
+# set variales for analysis of network
+#
+
+PREFIX="FR-IDF-rambouillet-interurbain"
+
+OVERPASS_QUERY="http://overpass-api.de/api/interpreter?data=area[wikidata=Q13917][type=boundary];(rel(area)[route~'bus'];rel(br);rel[type='route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r.routes);node(r.routes););out;"
+NETWORK_LONG=""
+NETWORK_SHORT="Rambouillet Interurbain"
+
+ANALYSIS_PAGE=""
+ANALYSIS_TALK=""
+#
+# Routes data is in GitHub only, not in OSM-Wiki
+#
+WIKI_ROUTES_PAGE=""
+
+ANALYSIS_OPTIONS="--check-access --check-bus-stop --check-name --check-osm-separator --check-sequence --check-stop-position --check-version --coloured-sketchline --check-motorway-link --max-error=10 --multiple-ref-type-entries=analyze --positive-notes"
+
+# --language=en
+# --check-bus-stop 
+# --expect-network-short
+# --expect-network-long
+# --expect-network-short-for=
+# --expect-network-long-for=
+# --relaxed-begin-end-for=
+
+    

--- a/FR-IDF-reseau-du-canton-de-perthes/FR-IDF-reseau-du-canton-de-perthes-Routes.txt
+++ b/FR-IDF-reseau-du-canton-de-perthes/FR-IDF-reseau-du-canton-de-perthes-Routes.txt
@@ -1,0 +1,69 @@
+
+#
+# This data is *not* stored in the OSM Wiki but in GitHub 
+#
+# Format: format is like in the OSM Wiki
+#
+# Links: [[...|...]] are interne link like in the OSM Wiki
+#        [... ...] are external links
+#
+# Headers start with '=', '==', '===', '====', ... at the beginning of a line
+#
+# Simple text starts with '-' at the beginning of a line.
+#    A single '-' at the beginning of a line, followed by nothing:
+#    - if there was simple text before, it creates a line feed (i.e. encloses the text in a paragraph <p> ... </p>)
+#    - if there was no simple text before or a line feed, it creates an empty line (i.e. <p>&amp;nbsp;</p>)
+#
+# !!!Text yellow background!!! in simple text or headers
+# '''''Text mit bold and italics''''' in simple text or headers
+# '''Text with bold chars''' in simple text or headers
+# ''Text with italic chars'' in simple text or headers
+#
+# Comments start with '#' at the beginning of a line. '#' inside text is not recognized as the start of a comment, i.e.. '#' may occur inside of text.
+#
+# Format of the file: UTF-8
+#
+#
+# Contents in CSV-Format - if ';' is part of the field, then enclose that field in "..."
+#
+# ref;type;comment;from;to;operator
+#
+# - ref       == tag 'ref' of route or route_master
+#                250            defines that routes with 'ref'='250' are expected
+#                250|250a|250b  defines that routes with 'ref'='250' or 'ref'='250a' or 'ref'='250b' are expected - independent of whether this is allowed according to PTv1/PTv2
+# - type      == contents of tags 'route' respectively 'route_master'
+# - comment   == can include comments like; Bus, Expressbus, ...  will not be analyzed, but simply be printed out
+#                !Text with yellow background! in comment (surrounded by single !)
+# - from      == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - to        == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - operator  == if there is more than one entry with "ref;type", then "operator" is used to distinguish between same line number in different cities/villages
+#
+
+
+= Overview on '''Réseau du Canton de Perthes''' Public Transport Lines
+
+-
+- '''!!!This summary is a list of what has been published in open data by Île-de-France Mobilités and found in OSM!!!'''
+-
+- Feel free to modify the list on github
+-
+#
+#ref;type;comment;from;to;operator
+
+== Lines
+01;bus;;;;
+09;bus;;;;
+101;bus;;;;
+109;bus;;;;
+11 GARE;bus;;;;
+111;bus;;;;
+11A;bus;;;;
+11B;bus;;;;
+11C;bus;;;;
+11CC;bus;;;;
+21;bus;;;;
+21CC;bus;;;;
+22A;bus;;;;
+22B;bus;;;;
+9CC;bus;;;;
+9M;bus;;;;

--- a/FR-IDF-reseau-du-canton-de-perthes/settings.sh
+++ b/FR-IDF-reseau-du-canton-de-perthes/settings.sh
@@ -1,0 +1,31 @@
+
+#!/bin/bash
+
+#
+# set variales for analysis of network
+#
+
+PREFIX="FR-IDF-reseau-du-canton-de-perthes"
+
+OVERPASS_QUERY="http://overpass-api.de/api/interpreter?data=area[wikidata=Q13917][type=boundary];(rel(area)[route~'bus'];rel(br);rel[type='route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r.routes);node(r.routes););out;"
+NETWORK_LONG=""
+NETWORK_SHORT="Réseau du Canton de Perthes"
+
+ANALYSIS_PAGE=""
+ANALYSIS_TALK=""
+#
+# Routes data is in GitHub only, not in OSM-Wiki
+#
+WIKI_ROUTES_PAGE=""
+
+ANALYSIS_OPTIONS="--check-access --check-bus-stop --check-name --check-osm-separator --check-sequence --check-stop-position --check-version --coloured-sketchline --check-motorway-link --max-error=10 --multiple-ref-type-entries=analyze --positive-notes"
+
+# --language=en
+# --check-bus-stop 
+# --expect-network-short
+# --expect-network-long
+# --expect-network-short-for=
+# --expect-network-long-for=
+# --relaxed-begin-end-for=
+
+    

--- a/FR-IDF-savac/FR-IDF-savac-Routes.txt
+++ b/FR-IDF-savac/FR-IDF-savac-Routes.txt
@@ -1,0 +1,111 @@
+
+#
+# This data is *not* stored in the OSM Wiki but in GitHub 
+#
+# Format: format is like in the OSM Wiki
+#
+# Links: [[...|...]] are interne link like in the OSM Wiki
+#        [... ...] are external links
+#
+# Headers start with '=', '==', '===', '====', ... at the beginning of a line
+#
+# Simple text starts with '-' at the beginning of a line.
+#    A single '-' at the beginning of a line, followed by nothing:
+#    - if there was simple text before, it creates a line feed (i.e. encloses the text in a paragraph <p> ... </p>)
+#    - if there was no simple text before or a line feed, it creates an empty line (i.e. <p>&amp;nbsp;</p>)
+#
+# !!!Text yellow background!!! in simple text or headers
+# '''''Text mit bold and italics''''' in simple text or headers
+# '''Text with bold chars''' in simple text or headers
+# ''Text with italic chars'' in simple text or headers
+#
+# Comments start with '#' at the beginning of a line. '#' inside text is not recognized as the start of a comment, i.e.. '#' may occur inside of text.
+#
+# Format of the file: UTF-8
+#
+#
+# Contents in CSV-Format - if ';' is part of the field, then enclose that field in "..."
+#
+# ref;type;comment;from;to;operator
+#
+# - ref       == tag 'ref' of route or route_master
+#                250            defines that routes with 'ref'='250' are expected
+#                250|250a|250b  defines that routes with 'ref'='250' or 'ref'='250a' or 'ref'='250b' are expected - independent of whether this is allowed according to PTv1/PTv2
+# - type      == contents of tags 'route' respectively 'route_master'
+# - comment   == can include comments like; Bus, Expressbus, ...  will not be analyzed, but simply be printed out
+#                !Text with yellow background! in comment (surrounded by single !)
+# - from      == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - to        == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - operator  == if there is more than one entry with "ref;type", then "operator" is used to distinguish between same line number in different cities/villages
+#
+
+
+= Overview on '''SAVAC''' Public Transport Lines
+
+-
+- '''!!!This summary is a list of what has been published in open data by Île-de-France Mobilités and found in OSM!!!'''
+-
+- Feel free to modify the list on github
+-
+#
+#ref;type;comment;from;to;operator
+
+== Lines
+10;bus;;;;
+11;bus;;;;
+12;bus;;;;
+13;bus;;;;
+260;bus;;;;
+261;bus;;;;
+262;bus;;;;
+263;bus;;;;
+264;bus;;;;
+307;bus;;;;
+39-003;bus;;;;
+39-02;bus;;;;
+39-05;bus;;;;
+39-07;bus;;;;
+39-07 A;bus;;;;
+39-07 B;bus;;;;
+39-07 C;bus;;;;
+39-07 D;bus;;;;
+39-10;bus;;;;
+39-103;bus;;;;
+39-12;bus;;;;
+39-13;bus;;;;
+39-17;bus;;;;
+39-18;bus;;;;
+39-203;bus;;;;
+39-27;bus;;;;
+39-28 A;bus;;;;
+39-28 B;bus;;;;
+39-28 C;bus;;;;
+39-28 D;bus;;;;
+39-28 E;bus;;;;
+39-28 F;bus;;;;
+39-29-1;bus;;;;
+39-29-2;bus;;;;
+39-29-3;bus;;;;
+39-29-4;bus;;;;
+39-30 A;bus;;;;
+39-30 B;bus;;;;
+39-30 C;bus;;;;
+39-30 D;bus;;;;
+39-303;bus;;;;
+39-31;bus;;;;
+39-34;bus;;;;
+39-35 A;bus;;;;
+39-35 B;bus;;;;
+39-36;bus;;;;
+39-37 A;bus;;;;
+39-37 AB;bus;;;;
+39-37 B;bus;;;;
+39-37 C;bus;;;;
+39-37 D;bus;;;;
+39-37 E;bus;;;;
+39-37 F;bus;;;;
+39-37 G;bus;;;;
+39-37 H;bus;;;;
+39-38;bus;;;;
+39-403;bus;;;;
+Vanves;bus;;;;

--- a/FR-IDF-savac/settings.sh
+++ b/FR-IDF-savac/settings.sh
@@ -1,0 +1,31 @@
+
+#!/bin/bash
+
+#
+# set variales for analysis of network
+#
+
+PREFIX="FR-IDF-savac"
+
+OVERPASS_QUERY="http://overpass-api.de/api/interpreter?data=area[wikidata=Q13917][type=boundary];(rel(area)[route~'bus'];rel(br);rel[type='route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r.routes);node(r.routes););out;"
+NETWORK_LONG=""
+NETWORK_SHORT="SAVAC"
+
+ANALYSIS_PAGE=""
+ANALYSIS_TALK=""
+#
+# Routes data is in GitHub only, not in OSM-Wiki
+#
+WIKI_ROUTES_PAGE=""
+
+ANALYSIS_OPTIONS="--check-access --check-bus-stop --check-name --check-osm-separator --check-sequence --check-stop-position --check-version --coloured-sketchline --check-motorway-link --max-error=10 --multiple-ref-type-entries=analyze --positive-notes"
+
+# --language=en
+# --check-bus-stop 
+# --expect-network-short
+# --expect-network-long
+# --expect-network-short-for=
+# --expect-network-long-for=
+# --relaxed-begin-end-for=
+
+    

--- a/FR-IDF-seine-et-marne-express/FR-IDF-seine-et-marne-express-Routes.txt
+++ b/FR-IDF-seine-et-marne-express/FR-IDF-seine-et-marne-express-Routes.txt
@@ -1,0 +1,65 @@
+
+#
+# This data is *not* stored in the OSM Wiki but in GitHub 
+#
+# Format: format is like in the OSM Wiki
+#
+# Links: [[...|...]] are interne link like in the OSM Wiki
+#        [... ...] are external links
+#
+# Headers start with '=', '==', '===', '====', ... at the beginning of a line
+#
+# Simple text starts with '-' at the beginning of a line.
+#    A single '-' at the beginning of a line, followed by nothing:
+#    - if there was simple text before, it creates a line feed (i.e. encloses the text in a paragraph <p> ... </p>)
+#    - if there was no simple text before or a line feed, it creates an empty line (i.e. <p>&amp;nbsp;</p>)
+#
+# !!!Text yellow background!!! in simple text or headers
+# '''''Text mit bold and italics''''' in simple text or headers
+# '''Text with bold chars''' in simple text or headers
+# ''Text with italic chars'' in simple text or headers
+#
+# Comments start with '#' at the beginning of a line. '#' inside text is not recognized as the start of a comment, i.e.. '#' may occur inside of text.
+#
+# Format of the file: UTF-8
+#
+#
+# Contents in CSV-Format - if ';' is part of the field, then enclose that field in "..."
+#
+# ref;type;comment;from;to;operator
+#
+# - ref       == tag 'ref' of route or route_master
+#                250            defines that routes with 'ref'='250' are expected
+#                250|250a|250b  defines that routes with 'ref'='250' or 'ref'='250a' or 'ref'='250b' are expected - independent of whether this is allowed according to PTv1/PTv2
+# - type      == contents of tags 'route' respectively 'route_master'
+# - comment   == can include comments like; Bus, Expressbus, ...  will not be analyzed, but simply be printed out
+#                !Text with yellow background! in comment (surrounded by single !)
+# - from      == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - to        == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - operator  == if there is more than one entry with "ref;type", then "operator" is used to distinguish between same line number in different cities/villages
+#
+
+
+= Overview on '''Seine et Marne Express''' Public Transport Lines
+
+-
+- '''!!!This summary is a list of what has been published in open data by Île-de-France Mobilités and found in OSM!!!'''
+-
+- Feel free to modify the list on github
+-
+#
+#ref;type;comment;from;to;operator
+
+== Lines
+01;bus;;;;
+07;bus;;;;
+16;bus;;;;
+17;bus;;;;
+18;bus;;;;
+19;bus;;;;
+46;bus;;;;
+47;bus;;;;
+50;bus;;;;
+69;bus;;;;
+EXPRESS34;bus;;;;
+Express20;bus;;;;

--- a/FR-IDF-seine-et-marne-express/settings.sh
+++ b/FR-IDF-seine-et-marne-express/settings.sh
@@ -1,0 +1,31 @@
+
+#!/bin/bash
+
+#
+# set variales for analysis of network
+#
+
+PREFIX="FR-IDF-seine-et-marne-express"
+
+OVERPASS_QUERY="http://overpass-api.de/api/interpreter?data=area[wikidata=Q13917][type=boundary];(rel(area)[route~'bus'];rel(br);rel[type='route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r.routes);node(r.routes););out;"
+NETWORK_LONG=""
+NETWORK_SHORT="Seine et Marne Express"
+
+ANALYSIS_PAGE=""
+ANALYSIS_TALK=""
+#
+# Routes data is in GitHub only, not in OSM-Wiki
+#
+WIKI_ROUTES_PAGE=""
+
+ANALYSIS_OPTIONS="--check-access --check-bus-stop --check-name --check-osm-separator --check-sequence --check-stop-position --check-version --coloured-sketchline --check-motorway-link --max-error=10 --multiple-ref-type-entries=analyze --positive-notes"
+
+# --language=en
+# --check-bus-stop 
+# --expect-network-short
+# --expect-network-long
+# --expect-network-short-for=
+# --expect-network-long-for=
+# --relaxed-begin-end-for=
+
+    

--- a/FR-IDF-seine-saint-denis/FR-IDF-seine-saint-denis-Routes.txt
+++ b/FR-IDF-seine-saint-denis/FR-IDF-seine-saint-denis-Routes.txt
@@ -1,0 +1,77 @@
+
+#
+# This data is *not* stored in the OSM Wiki but in GitHub 
+#
+# Format: format is like in the OSM Wiki
+#
+# Links: [[...|...]] are interne link like in the OSM Wiki
+#        [... ...] are external links
+#
+# Headers start with '=', '==', '===', '====', ... at the beginning of a line
+#
+# Simple text starts with '-' at the beginning of a line.
+#    A single '-' at the beginning of a line, followed by nothing:
+#    - if there was simple text before, it creates a line feed (i.e. encloses the text in a paragraph <p> ... </p>)
+#    - if there was no simple text before or a line feed, it creates an empty line (i.e. <p>&amp;nbsp;</p>)
+#
+# !!!Text yellow background!!! in simple text or headers
+# '''''Text mit bold and italics''''' in simple text or headers
+# '''Text with bold chars''' in simple text or headers
+# ''Text with italic chars'' in simple text or headers
+#
+# Comments start with '#' at the beginning of a line. '#' inside text is not recognized as the start of a comment, i.e.. '#' may occur inside of text.
+#
+# Format of the file: UTF-8
+#
+#
+# Contents in CSV-Format - if ';' is part of the field, then enclose that field in "..."
+#
+# ref;type;comment;from;to;operator
+#
+# - ref       == tag 'ref' of route or route_master
+#                250            defines that routes with 'ref'='250' are expected
+#                250|250a|250b  defines that routes with 'ref'='250' or 'ref'='250a' or 'ref'='250b' are expected - independent of whether this is allowed according to PTv1/PTv2
+# - type      == contents of tags 'route' respectively 'route_master'
+# - comment   == can include comments like; Bus, Expressbus, ...  will not be analyzed, but simply be printed out
+#                !Text with yellow background! in comment (surrounded by single !)
+# - from      == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - to        == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - operator  == if there is more than one entry with "ref;type", then "operator" is used to distinguish between same line number in different cities/villages
+#
+
+
+= Overview on '''Seine-Saint-Denis''' Public Transport Lines
+
+-
+- '''!!!This summary is a list of what has been published in open data by Île-de-France Mobilités and found in OSM!!!'''
+-
+- Feel free to modify the list on github
+-
+#
+#ref;type;comment;from;to;operator
+
+== Lines
+601;bus;;;;
+602;bus;;;;
+603;bus;;;;
+604;bus;;;;
+605;bus;;;;
+607;bus;;;;
+609;bus;;;;
+610;bus;;;;
+611;bus;;;;
+613;bus;;;;
+615;bus;;;;
+616;bus;;;;
+617;bus;;;;
+618;bus;;;;
+619;bus;;;;
+620;bus;;;;
+623;bus;;;;
+627;bus;;;;
+637;bus;;;;
+640;bus;;;;
+642;bus;;;;
+643;bus;;;;
+644;bus;;;;
+645;bus;;;;

--- a/FR-IDF-seine-saint-denis/settings.sh
+++ b/FR-IDF-seine-saint-denis/settings.sh
@@ -1,0 +1,31 @@
+
+#!/bin/bash
+
+#
+# set variales for analysis of network
+#
+
+PREFIX="FR-IDF-seine-saint-denis"
+
+OVERPASS_QUERY="http://overpass-api.de/api/interpreter?data=area[wikidata=Q13917][type=boundary];(rel(area)[route~'bus'];rel(br);rel[type='route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r.routes);node(r.routes););out;"
+NETWORK_LONG=""
+NETWORK_SHORT="Seine-Saint-Denis"
+
+ANALYSIS_PAGE=""
+ANALYSIS_TALK=""
+#
+# Routes data is in GitHub only, not in OSM-Wiki
+#
+WIKI_ROUTES_PAGE=""
+
+ANALYSIS_OPTIONS="--check-access --check-bus-stop --check-name --check-osm-separator --check-sequence --check-stop-position --check-version --coloured-sketchline --check-motorway-link --max-error=10 --multiple-ref-type-entries=analyze --positive-notes"
+
+# --language=en
+# --check-bus-stop 
+# --expect-network-short
+# --expect-network-long
+# --expect-network-short-for=
+# --expect-network-long-for=
+# --relaxed-begin-end-for=
+
+    

--- a/FR-IDF-seine-senart-bus/FR-IDF-seine-senart-bus-Routes.txt
+++ b/FR-IDF-seine-senart-bus/FR-IDF-seine-senart-bus-Routes.txt
@@ -1,0 +1,80 @@
+
+#
+# This data is *not* stored in the OSM Wiki but in GitHub 
+#
+# Format: format is like in the OSM Wiki
+#
+# Links: [[...|...]] are interne link like in the OSM Wiki
+#        [... ...] are external links
+#
+# Headers start with '=', '==', '===', '====', ... at the beginning of a line
+#
+# Simple text starts with '-' at the beginning of a line.
+#    A single '-' at the beginning of a line, followed by nothing:
+#    - if there was simple text before, it creates a line feed (i.e. encloses the text in a paragraph <p> ... </p>)
+#    - if there was no simple text before or a line feed, it creates an empty line (i.e. <p>&amp;nbsp;</p>)
+#
+# !!!Text yellow background!!! in simple text or headers
+# '''''Text mit bold and italics''''' in simple text or headers
+# '''Text with bold chars''' in simple text or headers
+# ''Text with italic chars'' in simple text or headers
+#
+# Comments start with '#' at the beginning of a line. '#' inside text is not recognized as the start of a comment, i.e.. '#' may occur inside of text.
+#
+# Format of the file: UTF-8
+#
+#
+# Contents in CSV-Format - if ';' is part of the field, then enclose that field in "..."
+#
+# ref;type;comment;from;to;operator
+#
+# - ref       == tag 'ref' of route or route_master
+#                250            defines that routes with 'ref'='250' are expected
+#                250|250a|250b  defines that routes with 'ref'='250' or 'ref'='250a' or 'ref'='250b' are expected - independent of whether this is allowed according to PTv1/PTv2
+# - type      == contents of tags 'route' respectively 'route_master'
+# - comment   == can include comments like; Bus, Expressbus, ...  will not be analyzed, but simply be printed out
+#                !Text with yellow background! in comment (surrounded by single !)
+# - from      == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - to        == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - operator  == if there is more than one entry with "ref;type", then "operator" is used to distinguish between same line number in different cities/villages
+#
+
+
+= Overview on '''Seine Sénart Bus''' Public Transport Lines
+
+-
+- '''!!!This summary is a list of what has been published in open data by Île-de-France Mobilités and found in OSM!!!'''
+-
+- Feel free to modify the list on github
+-
+#
+#ref;type;comment;from;to;operator
+
+== Lines
+11L;bus;;;;
+12;bus;;;;
+13;bus;;;;
+14;bus;;;;
+16;bus;;;;
+17;bus;;;;
+18;bus;;;;
+19;bus;;;;
+4;bus;;;;
+501;bus;;;;
+A;bus;;;;
+B;bus;;;;
+BM;bus;;;;
+C;bus;;;;
+D;bus;;;;
+E;bus;;;;
+F;bus;;;;
+G;bus;;;;
+H;bus;;;;
+Inter-Val;bus;;;;
+LM1;bus;;;;
+LM2;bus;;;;
+LM3;bus;;;;
+LP1;bus;;;;
+LP2;bus;;;;
+RD15;bus;;;;
+RD16;bus;;;;

--- a/FR-IDF-seine-senart-bus/settings.sh
+++ b/FR-IDF-seine-senart-bus/settings.sh
@@ -1,0 +1,31 @@
+
+#!/bin/bash
+
+#
+# set variales for analysis of network
+#
+
+PREFIX="FR-IDF-seine-senart-bus"
+
+OVERPASS_QUERY="http://overpass-api.de/api/interpreter?data=area[wikidata=Q13917][type=boundary];(rel(area)[route~'bus'];rel(br);rel[type='route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r.routes);node(r.routes););out;"
+NETWORK_LONG=""
+NETWORK_SHORT="Seine Sénart Bus"
+
+ANALYSIS_PAGE=""
+ANALYSIS_TALK=""
+#
+# Routes data is in GitHub only, not in OSM-Wiki
+#
+WIKI_ROUTES_PAGE=""
+
+ANALYSIS_OPTIONS="--check-access --check-bus-stop --check-name --check-osm-separator --check-sequence --check-stop-position --check-version --coloured-sketchline --check-motorway-link --max-error=10 --multiple-ref-type-entries=analyze --positive-notes"
+
+# --language=en
+# --check-bus-stop 
+# --expect-network-short
+# --expect-network-long
+# --expect-network-short-for=
+# --expect-network-long-for=
+# --relaxed-begin-end-for=
+
+    

--- a/FR-IDF-senart-bus/FR-IDF-senart-bus-Routes.txt
+++ b/FR-IDF-senart-bus/FR-IDF-senart-bus-Routes.txt
@@ -1,0 +1,91 @@
+
+#
+# This data is *not* stored in the OSM Wiki but in GitHub 
+#
+# Format: format is like in the OSM Wiki
+#
+# Links: [[...|...]] are interne link like in the OSM Wiki
+#        [... ...] are external links
+#
+# Headers start with '=', '==', '===', '====', ... at the beginning of a line
+#
+# Simple text starts with '-' at the beginning of a line.
+#    A single '-' at the beginning of a line, followed by nothing:
+#    - if there was simple text before, it creates a line feed (i.e. encloses the text in a paragraph <p> ... </p>)
+#    - if there was no simple text before or a line feed, it creates an empty line (i.e. <p>&amp;nbsp;</p>)
+#
+# !!!Text yellow background!!! in simple text or headers
+# '''''Text mit bold and italics''''' in simple text or headers
+# '''Text with bold chars''' in simple text or headers
+# ''Text with italic chars'' in simple text or headers
+#
+# Comments start with '#' at the beginning of a line. '#' inside text is not recognized as the start of a comment, i.e.. '#' may occur inside of text.
+#
+# Format of the file: UTF-8
+#
+#
+# Contents in CSV-Format - if ';' is part of the field, then enclose that field in "..."
+#
+# ref;type;comment;from;to;operator
+#
+# - ref       == tag 'ref' of route or route_master
+#                250            defines that routes with 'ref'='250' are expected
+#                250|250a|250b  defines that routes with 'ref'='250' or 'ref'='250a' or 'ref'='250b' are expected - independent of whether this is allowed according to PTv1/PTv2
+# - type      == contents of tags 'route' respectively 'route_master'
+# - comment   == can include comments like; Bus, Expressbus, ...  will not be analyzed, but simply be printed out
+#                !Text with yellow background! in comment (surrounded by single !)
+# - from      == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - to        == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - operator  == if there is more than one entry with "ref;type", then "operator" is used to distinguish between same line number in different cities/villages
+#
+
+
+= Overview on '''Sénart-Bus''' Public Transport Lines
+
+-
+- '''!!!This summary is a list of what has been published in open data by Île-de-France Mobilités and found in OSM!!!'''
+-
+- Feel free to modify the list on github
+-
+#
+#ref;type;comment;from;to;operator
+
+== Lines
+01;bus;;;;
+02;bus;;;;
+03;bus;;;;
+04;bus;;;;
+05;bus;;;;
+11;bus;;;;
+12;bus;;;;
+13;bus;;;;
+21;bus;;;;
+22;bus;;;;
+23;bus;;;;
+24;bus;;;;
+25;bus;;;;
+26;bus;;;;
+27;bus;;;;
+31;bus;;;;
+32;bus;;;;
+33;bus;;;;
+34;bus;;;;
+35;bus;;;;
+36;bus;;;;
+37;bus;;;;
+41;bus;;;;
+42;bus;;;;
+42P;bus;;;;
+43;bus;;;;
+43P;bus;;;;
+52;bus;;;;
+53;bus;;;;
+61A;bus;;;;
+61B;bus;;;;
+62A;bus;;;;
+62B;bus;;;;
+62C;bus;;;;
+63;bus;;;;
+64;bus;;;;
+CPSF;bus;;;;
+Tzen1;bus;;;;

--- a/FR-IDF-senart-bus/settings.sh
+++ b/FR-IDF-senart-bus/settings.sh
@@ -1,0 +1,31 @@
+
+#!/bin/bash
+
+#
+# set variales for analysis of network
+#
+
+PREFIX="FR-IDF-senart-bus"
+
+OVERPASS_QUERY="http://overpass-api.de/api/interpreter?data=area[wikidata=Q13917][type=boundary];(rel(area)[route~'bus'];rel(br);rel[type='route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r.routes);node(r.routes););out;"
+NETWORK_LONG=""
+NETWORK_SHORT="Sénart-Bus"
+
+ANALYSIS_PAGE=""
+ANALYSIS_TALK=""
+#
+# Routes data is in GitHub only, not in OSM-Wiki
+#
+WIKI_ROUTES_PAGE=""
+
+ANALYSIS_OPTIONS="--check-access --check-bus-stop --check-name --check-osm-separator --check-sequence --check-stop-position --check-version --coloured-sketchline --check-motorway-link --max-error=10 --multiple-ref-type-entries=analyze --positive-notes"
+
+# --language=en
+# --check-bus-stop 
+# --expect-network-short
+# --expect-network-long
+# --expect-network-short-for=
+# --expect-network-long-for=
+# --relaxed-begin-end-for=
+
+    

--- a/FR-IDF-situs/FR-IDF-situs-Routes.txt
+++ b/FR-IDF-situs/FR-IDF-situs-Routes.txt
@@ -1,0 +1,69 @@
+
+#
+# This data is *not* stored in the OSM Wiki but in GitHub 
+#
+# Format: format is like in the OSM Wiki
+#
+# Links: [[...|...]] are interne link like in the OSM Wiki
+#        [... ...] are external links
+#
+# Headers start with '=', '==', '===', '====', ... at the beginning of a line
+#
+# Simple text starts with '-' at the beginning of a line.
+#    A single '-' at the beginning of a line, followed by nothing:
+#    - if there was simple text before, it creates a line feed (i.e. encloses the text in a paragraph <p> ... </p>)
+#    - if there was no simple text before or a line feed, it creates an empty line (i.e. <p>&amp;nbsp;</p>)
+#
+# !!!Text yellow background!!! in simple text or headers
+# '''''Text mit bold and italics''''' in simple text or headers
+# '''Text with bold chars''' in simple text or headers
+# ''Text with italic chars'' in simple text or headers
+#
+# Comments start with '#' at the beginning of a line. '#' inside text is not recognized as the start of a comment, i.e.. '#' may occur inside of text.
+#
+# Format of the file: UTF-8
+#
+#
+# Contents in CSV-Format - if ';' is part of the field, then enclose that field in "..."
+#
+# ref;type;comment;from;to;operator
+#
+# - ref       == tag 'ref' of route or route_master
+#                250            defines that routes with 'ref'='250' are expected
+#                250|250a|250b  defines that routes with 'ref'='250' or 'ref'='250a' or 'ref'='250b' are expected - independent of whether this is allowed according to PTv1/PTv2
+# - type      == contents of tags 'route' respectively 'route_master'
+# - comment   == can include comments like; Bus, Expressbus, ...  will not be analyzed, but simply be printed out
+#                !Text with yellow background! in comment (surrounded by single !)
+# - from      == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - to        == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - operator  == if there is more than one entry with "ref;type", then "operator" is used to distinguish between same line number in different cities/villages
+#
+
+
+= Overview on '''SITUS''' Public Transport Lines
+
+-
+- '''!!!This summary is a list of what has been published in open data by Île-de-France Mobilités and found in OSM!!!'''
+-
+- Feel free to modify the list on github
+-
+#
+#ref;type;comment;from;to;operator
+
+== Lines
+1;bus;;;;
+10;bus;;;;
+102;bus;;;;
+103;bus;;;;
+2;bus;;;;
+3;bus;;;;
+4;bus;;;;
+41;bus;;;;
+42;bus;;;;
+43;bus;;;;
+44;bus;;;;
+45;bus;;;;
+5;bus;;;;
+6;bus;;;;
+7;bus;;;;
+8;bus;;;;

--- a/FR-IDF-situs/settings.sh
+++ b/FR-IDF-situs/settings.sh
@@ -1,0 +1,31 @@
+
+#!/bin/bash
+
+#
+# set variales for analysis of network
+#
+
+PREFIX="FR-IDF-situs"
+
+OVERPASS_QUERY="http://overpass-api.de/api/interpreter?data=area[wikidata=Q13917][type=boundary];(rel(area)[route~'bus'];rel(br);rel[type='route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r.routes);node(r.routes););out;"
+NETWORK_LONG=""
+NETWORK_SHORT="SITUS"
+
+ANALYSIS_PAGE=""
+ANALYSIS_TALK=""
+#
+# Routes data is in GitHub only, not in OSM-Wiki
+#
+WIKI_ROUTES_PAGE=""
+
+ANALYSIS_OPTIONS="--check-access --check-bus-stop --check-name --check-osm-separator --check-sequence --check-stop-position --check-version --coloured-sketchline --check-motorway-link --max-error=10 --multiple-ref-type-entries=analyze --positive-notes"
+
+# --language=en
+# --check-bus-stop 
+# --expect-network-short
+# --expect-network-long
+# --expect-network-short-for=
+# --expect-network-long-for=
+# --relaxed-begin-end-for=
+
+    

--- a/FR-IDF-siyonne/FR-IDF-siyonne-Routes.txt
+++ b/FR-IDF-siyonne/FR-IDF-siyonne-Routes.txt
@@ -1,0 +1,64 @@
+
+#
+# This data is *not* stored in the OSM Wiki but in GitHub 
+#
+# Format: format is like in the OSM Wiki
+#
+# Links: [[...|...]] are interne link like in the OSM Wiki
+#        [... ...] are external links
+#
+# Headers start with '=', '==', '===', '====', ... at the beginning of a line
+#
+# Simple text starts with '-' at the beginning of a line.
+#    A single '-' at the beginning of a line, followed by nothing:
+#    - if there was simple text before, it creates a line feed (i.e. encloses the text in a paragraph <p> ... </p>)
+#    - if there was no simple text before or a line feed, it creates an empty line (i.e. <p>&amp;nbsp;</p>)
+#
+# !!!Text yellow background!!! in simple text or headers
+# '''''Text mit bold and italics''''' in simple text or headers
+# '''Text with bold chars''' in simple text or headers
+# ''Text with italic chars'' in simple text or headers
+#
+# Comments start with '#' at the beginning of a line. '#' inside text is not recognized as the start of a comment, i.e.. '#' may occur inside of text.
+#
+# Format of the file: UTF-8
+#
+#
+# Contents in CSV-Format - if ';' is part of the field, then enclose that field in "..."
+#
+# ref;type;comment;from;to;operator
+#
+# - ref       == tag 'ref' of route or route_master
+#                250            defines that routes with 'ref'='250' are expected
+#                250|250a|250b  defines that routes with 'ref'='250' or 'ref'='250a' or 'ref'='250b' are expected - independent of whether this is allowed according to PTv1/PTv2
+# - type      == contents of tags 'route' respectively 'route_master'
+# - comment   == can include comments like; Bus, Expressbus, ...  will not be analyzed, but simply be printed out
+#                !Text with yellow background! in comment (surrounded by single !)
+# - from      == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - to        == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - operator  == if there is more than one entry with "ref;type", then "operator" is used to distinguish between same line number in different cities/villages
+#
+
+
+= Overview on '''Siyonne''' Public Transport Lines
+
+-
+- '''!!!This summary is a list of what has been published in open data by Île-de-France Mobilités and found in OSM!!!'''
+-
+- Feel free to modify the list on github
+-
+#
+#ref;type;comment;from;to;operator
+
+== Lines
+15;bus;;;;
+A;bus;;;;
+B;bus;;;;
+C;bus;;;;
+Ea;bus;;;;
+Eb;bus;;;;
+Emplet;bus;;;;
+F;bus;;;;
+G;bus;;;;
+I;bus;;;;
+L;bus;;;;

--- a/FR-IDF-siyonne/settings.sh
+++ b/FR-IDF-siyonne/settings.sh
@@ -1,0 +1,31 @@
+
+#!/bin/bash
+
+#
+# set variales for analysis of network
+#
+
+PREFIX="FR-IDF-siyonne"
+
+OVERPASS_QUERY="http://overpass-api.de/api/interpreter?data=area[wikidata=Q13917][type=boundary];(rel(area)[route~'bus'];rel(br);rel[type='route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r.routes);node(r.routes););out;"
+NETWORK_LONG=""
+NETWORK_SHORT="Siyonne"
+
+ANALYSIS_PAGE=""
+ANALYSIS_TALK=""
+#
+# Routes data is in GitHub only, not in OSM-Wiki
+#
+WIKI_ROUTES_PAGE=""
+
+ANALYSIS_OPTIONS="--check-access --check-bus-stop --check-name --check-osm-separator --check-sequence --check-stop-position --check-version --coloured-sketchline --check-motorway-link --max-error=10 --multiple-ref-type-entries=analyze --positive-notes"
+
+# --language=en
+# --check-bus-stop 
+# --expect-network-short
+# --expect-network-long
+# --expect-network-short-for=
+# --expect-network-long-for=
+# --relaxed-begin-end-for=
+
+    

--- a/FR-IDF-sol-r/FR-IDF-sol-r-Routes.txt
+++ b/FR-IDF-sol-r/FR-IDF-sol-r-Routes.txt
@@ -1,0 +1,66 @@
+
+#
+# This data is *not* stored in the OSM Wiki but in GitHub 
+#
+# Format: format is like in the OSM Wiki
+#
+# Links: [[...|...]] are interne link like in the OSM Wiki
+#        [... ...] are external links
+#
+# Headers start with '=', '==', '===', '====', ... at the beginning of a line
+#
+# Simple text starts with '-' at the beginning of a line.
+#    A single '-' at the beginning of a line, followed by nothing:
+#    - if there was simple text before, it creates a line feed (i.e. encloses the text in a paragraph <p> ... </p>)
+#    - if there was no simple text before or a line feed, it creates an empty line (i.e. <p>&amp;nbsp;</p>)
+#
+# !!!Text yellow background!!! in simple text or headers
+# '''''Text mit bold and italics''''' in simple text or headers
+# '''Text with bold chars''' in simple text or headers
+# ''Text with italic chars'' in simple text or headers
+#
+# Comments start with '#' at the beginning of a line. '#' inside text is not recognized as the start of a comment, i.e.. '#' may occur inside of text.
+#
+# Format of the file: UTF-8
+#
+#
+# Contents in CSV-Format - if ';' is part of the field, then enclose that field in "..."
+#
+# ref;type;comment;from;to;operator
+#
+# - ref       == tag 'ref' of route or route_master
+#                250            defines that routes with 'ref'='250' are expected
+#                250|250a|250b  defines that routes with 'ref'='250' or 'ref'='250a' or 'ref'='250b' are expected - independent of whether this is allowed according to PTv1/PTv2
+# - type      == contents of tags 'route' respectively 'route_master'
+# - comment   == can include comments like; Bus, Expressbus, ...  will not be analyzed, but simply be printed out
+#                !Text with yellow background! in comment (surrounded by single !)
+# - from      == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - to        == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - operator  == if there is more than one entry with "ref;type", then "operator" is used to distinguish between same line number in different cities/villages
+#
+
+
+= Overview on '''Sol'R''' Public Transport Lines
+
+-
+- '''!!!This summary is a list of what has been published in open data by Île-de-France Mobilités and found in OSM!!!'''
+-
+- Feel free to modify the list on github
+-
+#
+#ref;type;comment;from;to;operator
+
+== Lines
+03;bus;;;;
+07;bus;;;;
+10;bus;;;;
+121;bus;;;;
+17;bus;;;;
+209;bus;;;;
+21;bus;;;;
+28A;bus;;;;
+28B;bus;;;;
+28C;bus;;;;
+309;bus;;;;
+33;bus;;;;
+409;bus;;;;

--- a/FR-IDF-sol-r/settings.sh
+++ b/FR-IDF-sol-r/settings.sh
@@ -1,0 +1,31 @@
+
+#!/bin/bash
+
+#
+# set variales for analysis of network
+#
+
+PREFIX="FR-IDF-sol-r"
+
+OVERPASS_QUERY="http://overpass-api.de/api/interpreter?data=area[wikidata=Q13917][type=boundary];(rel(area)[route~'bus'];rel(br);rel[type='route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r.routes);node(r.routes););out;"
+NETWORK_LONG=""
+NETWORK_SHORT="Sol'R"
+
+ANALYSIS_PAGE=""
+ANALYSIS_TALK=""
+#
+# Routes data is in GitHub only, not in OSM-Wiki
+#
+WIKI_ROUTES_PAGE=""
+
+ANALYSIS_OPTIONS="--check-access --check-bus-stop --check-name --check-osm-separator --check-sequence --check-stop-position --check-version --coloured-sketchline --check-motorway-link --max-error=10 --multiple-ref-type-entries=analyze --positive-notes"
+
+# --language=en
+# --check-bus-stop 
+# --expect-network-short
+# --expect-network-long
+# --expect-network-short-for=
+# --expect-network-long-for=
+# --relaxed-begin-end-for=
+
+    

--- a/FR-IDF-sqybus/FR-IDF-sqybus-Routes.txt
+++ b/FR-IDF-sqybus/FR-IDF-sqybus-Routes.txt
@@ -1,0 +1,91 @@
+
+#
+# This data is *not* stored in the OSM Wiki but in GitHub 
+#
+# Format: format is like in the OSM Wiki
+#
+# Links: [[...|...]] are interne link like in the OSM Wiki
+#        [... ...] are external links
+#
+# Headers start with '=', '==', '===', '====', ... at the beginning of a line
+#
+# Simple text starts with '-' at the beginning of a line.
+#    A single '-' at the beginning of a line, followed by nothing:
+#    - if there was simple text before, it creates a line feed (i.e. encloses the text in a paragraph <p> ... </p>)
+#    - if there was no simple text before or a line feed, it creates an empty line (i.e. <p>&amp;nbsp;</p>)
+#
+# !!!Text yellow background!!! in simple text or headers
+# '''''Text mit bold and italics''''' in simple text or headers
+# '''Text with bold chars''' in simple text or headers
+# ''Text with italic chars'' in simple text or headers
+#
+# Comments start with '#' at the beginning of a line. '#' inside text is not recognized as the start of a comment, i.e.. '#' may occur inside of text.
+#
+# Format of the file: UTF-8
+#
+#
+# Contents in CSV-Format - if ';' is part of the field, then enclose that field in "..."
+#
+# ref;type;comment;from;to;operator
+#
+# - ref       == tag 'ref' of route or route_master
+#                250            defines that routes with 'ref'='250' are expected
+#                250|250a|250b  defines that routes with 'ref'='250' or 'ref'='250a' or 'ref'='250b' are expected - independent of whether this is allowed according to PTv1/PTv2
+# - type      == contents of tags 'route' respectively 'route_master'
+# - comment   == can include comments like; Bus, Expressbus, ...  will not be analyzed, but simply be printed out
+#                !Text with yellow background! in comment (surrounded by single !)
+# - from      == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - to        == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - operator  == if there is more than one entry with "ref;type", then "operator" is used to distinguish between same line number in different cities/villages
+#
+
+
+= Overview on '''SQYBUS''' Public Transport Lines
+
+-
+- '''!!!This summary is a list of what has been published in open data by Île-de-France Mobilités and found in OSM!!!'''
+-
+- Feel free to modify the list on github
+-
+#
+#ref;type;comment;from;to;operator
+
+== Lines
+401;bus;;;;
+402;bus;;;;
+414;bus;;;;
+415;bus;;;;
+417;bus;;;;
+418;bus;;;;
+419;bus;;;;
+420;bus;;;;
+422;bus;;;;
+423;bus;;;;
+424;bus;;;;
+430;bus;;;;
+431;bus;;;;
+439;bus;;;;
+440;bus;;;;
+441;bus;;;;
+444;bus;;;;
+448;bus;;;;
+449;bus;;;;
+450;bus;;;;
+451;bus;;;;
+452;bus;;;;
+453;bus;;;;
+454;bus;;;;
+455;bus;;;;
+456;bus;;;;
+457;bus;;;;
+458;bus;;;;
+459;bus;;;;
+460;bus;;;;
+461;bus;;;;
+463;bus;;;;
+464;bus;;;;
+465;bus;;;;
+466;bus;;;;
+467;bus;;;;
+468;bus;;;;
+475;bus;;;;

--- a/FR-IDF-sqybus/settings.sh
+++ b/FR-IDF-sqybus/settings.sh
@@ -1,0 +1,31 @@
+
+#!/bin/bash
+
+#
+# set variales for analysis of network
+#
+
+PREFIX="FR-IDF-sqybus"
+
+OVERPASS_QUERY="http://overpass-api.de/api/interpreter?data=area[wikidata=Q13917][type=boundary];(rel(area)[route~'bus'];rel(br);rel[type='route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r.routes);node(r.routes););out;"
+NETWORK_LONG=""
+NETWORK_SHORT="SQYBUS"
+
+ANALYSIS_PAGE=""
+ANALYSIS_TALK=""
+#
+# Routes data is in GitHub only, not in OSM-Wiki
+#
+WIKI_ROUTES_PAGE=""
+
+ANALYSIS_OPTIONS="--check-access --check-bus-stop --check-name --check-osm-separator --check-sequence --check-stop-position --check-version --coloured-sketchline --check-motorway-link --max-error=10 --multiple-ref-type-entries=analyze --positive-notes"
+
+# --language=en
+# --check-bus-stop 
+# --expect-network-short
+# --expect-network-long
+# --expect-network-short-for=
+# --expect-network-long-for=
+# --relaxed-begin-end-for=
+
+    

--- a/FR-IDF-still/FR-IDF-still-Routes.txt
+++ b/FR-IDF-still/FR-IDF-still-Routes.txt
@@ -1,0 +1,85 @@
+
+#
+# This data is *not* stored in the OSM Wiki but in GitHub 
+#
+# Format: format is like in the OSM Wiki
+#
+# Links: [[...|...]] are interne link like in the OSM Wiki
+#        [... ...] are external links
+#
+# Headers start with '=', '==', '===', '====', ... at the beginning of a line
+#
+# Simple text starts with '-' at the beginning of a line.
+#    A single '-' at the beginning of a line, followed by nothing:
+#    - if there was simple text before, it creates a line feed (i.e. encloses the text in a paragraph <p> ... </p>)
+#    - if there was no simple text before or a line feed, it creates an empty line (i.e. <p>&amp;nbsp;</p>)
+#
+# !!!Text yellow background!!! in simple text or headers
+# '''''Text mit bold and italics''''' in simple text or headers
+# '''Text with bold chars''' in simple text or headers
+# ''Text with italic chars'' in simple text or headers
+#
+# Comments start with '#' at the beginning of a line. '#' inside text is not recognized as the start of a comment, i.e.. '#' may occur inside of text.
+#
+# Format of the file: UTF-8
+#
+#
+# Contents in CSV-Format - if ';' is part of the field, then enclose that field in "..."
+#
+# ref;type;comment;from;to;operator
+#
+# - ref       == tag 'ref' of route or route_master
+#                250            defines that routes with 'ref'='250' are expected
+#                250|250a|250b  defines that routes with 'ref'='250' or 'ref'='250a' or 'ref'='250b' are expected - independent of whether this is allowed according to PTv1/PTv2
+# - type      == contents of tags 'route' respectively 'route_master'
+# - comment   == can include comments like; Bus, Expressbus, ...  will not be analyzed, but simply be printed out
+#                !Text with yellow background! in comment (surrounded by single !)
+# - from      == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - to        == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - operator  == if there is more than one entry with "ref;type", then "operator" is used to distinguish between same line number in different cities/villages
+#
+
+
+= Overview on '''STILL''' Public Transport Lines
+
+-
+- '''!!!This summary is a list of what has been published in open data by Île-de-France Mobilités and found in OSM!!!'''
+-
+- Feel free to modify the list on github
+-
+#
+#ref;type;comment;from;to;operator
+
+== Lines
+1;bus;;;;
+10;bus;;;;
+11A;bus;;;;
+11B;bus;;;;
+11C;bus;;;;
+11D;bus;;;;
+12;bus;;;;
+13A;bus;;;;
+13B;bus;;;;
+13C;bus;;;;
+14A;bus;;;;
+14B;bus;;;;
+17A;bus;;;;
+17B;bus;;;;
+18A;bus;;;;
+18B;bus;;;;
+18C;bus;;;;
+19;bus;;;;
+2;bus;;;;
+3;bus;;;;
+4;bus;;;;
+5;bus;;;;
+7A;bus;;;;
+7B;bus;;;;
+7C;bus;;;;
+7D;bus;;;;
+8A;bus;;;;
+8B;bus;;;;
+9A;bus;;;;
+9B;bus;;;;
+9C;bus;;;;
+9D;bus;;;;

--- a/FR-IDF-still/settings.sh
+++ b/FR-IDF-still/settings.sh
@@ -1,0 +1,31 @@
+
+#!/bin/bash
+
+#
+# set variales for analysis of network
+#
+
+PREFIX="FR-IDF-still"
+
+OVERPASS_QUERY="http://overpass-api.de/api/interpreter?data=area[wikidata=Q13917][type=boundary];(rel(area)[route~'bus'];rel(br);rel[type='route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r.routes);node(r.routes););out;"
+NETWORK_LONG=""
+NETWORK_SHORT="STILL"
+
+ANALYSIS_PAGE=""
+ANALYSIS_TALK=""
+#
+# Routes data is in GitHub only, not in OSM-Wiki
+#
+WIKI_ROUTES_PAGE=""
+
+ANALYSIS_OPTIONS="--check-access --check-bus-stop --check-name --check-osm-separator --check-sequence --check-stop-position --check-version --coloured-sketchline --check-motorway-link --max-error=10 --multiple-ref-type-entries=analyze --positive-notes"
+
+# --language=en
+# --check-bus-stop 
+# --expect-network-short
+# --expect-network-long
+# --expect-network-short-for=
+# --expect-network-long-for=
+# --relaxed-begin-end-for=
+
+    

--- a/FR-IDF-stivo/FR-IDF-stivo-Routes.txt
+++ b/FR-IDF-stivo/FR-IDF-stivo-Routes.txt
@@ -1,0 +1,74 @@
+
+#
+# This data is *not* stored in the OSM Wiki but in GitHub 
+#
+# Format: format is like in the OSM Wiki
+#
+# Links: [[...|...]] are interne link like in the OSM Wiki
+#        [... ...] are external links
+#
+# Headers start with '=', '==', '===', '====', ... at the beginning of a line
+#
+# Simple text starts with '-' at the beginning of a line.
+#    A single '-' at the beginning of a line, followed by nothing:
+#    - if there was simple text before, it creates a line feed (i.e. encloses the text in a paragraph <p> ... </p>)
+#    - if there was no simple text before or a line feed, it creates an empty line (i.e. <p>&amp;nbsp;</p>)
+#
+# !!!Text yellow background!!! in simple text or headers
+# '''''Text mit bold and italics''''' in simple text or headers
+# '''Text with bold chars''' in simple text or headers
+# ''Text with italic chars'' in simple text or headers
+#
+# Comments start with '#' at the beginning of a line. '#' inside text is not recognized as the start of a comment, i.e.. '#' may occur inside of text.
+#
+# Format of the file: UTF-8
+#
+#
+# Contents in CSV-Format - if ';' is part of the field, then enclose that field in "..."
+#
+# ref;type;comment;from;to;operator
+#
+# - ref       == tag 'ref' of route or route_master
+#                250            defines that routes with 'ref'='250' are expected
+#                250|250a|250b  defines that routes with 'ref'='250' or 'ref'='250a' or 'ref'='250b' are expected - independent of whether this is allowed according to PTv1/PTv2
+# - type      == contents of tags 'route' respectively 'route_master'
+# - comment   == can include comments like; Bus, Expressbus, ...  will not be analyzed, but simply be printed out
+#                !Text with yellow background! in comment (surrounded by single !)
+# - from      == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - to        == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - operator  == if there is more than one entry with "ref;type", then "operator" is used to distinguish between same line number in different cities/villages
+#
+
+
+= Overview on '''STIVO''' Public Transport Lines
+
+-
+- '''!!!This summary is a list of what has been published in open data by Île-de-France Mobilités and found in OSM!!!'''
+-
+- Feel free to modify the list on github
+-
+#
+#ref;type;comment;from;to;operator
+
+== Lines
+30;bus;;;;
+33;bus;;;;
+34;bus;;;;
+35;bus;;;;
+36;bus;;;;
+38;bus;;;;
+39;bus;;;;
+40;bus;;;;
+42;bus;;;;
+43;bus;;;;
+44;bus;;;;
+45;bus;;;;
+47;bus;;;;
+48;bus;;;;
+49;bus;;;;
+55;bus;;;;
+56;bus;;;;
+57;bus;;;;
+58;bus;;;;
+59;bus;;;;
+60;bus;;;;

--- a/FR-IDF-stivo/settings.sh
+++ b/FR-IDF-stivo/settings.sh
@@ -1,0 +1,31 @@
+
+#!/bin/bash
+
+#
+# set variales for analysis of network
+#
+
+PREFIX="FR-IDF-stivo"
+
+OVERPASS_QUERY="http://overpass-api.de/api/interpreter?data=area[wikidata=Q13917][type=boundary];(rel(area)[route~'bus'];rel(br);rel[type='route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r.routes);node(r.routes););out;"
+NETWORK_LONG=""
+NETWORK_SHORT="STIVO"
+
+ANALYSIS_PAGE=""
+ANALYSIS_TALK=""
+#
+# Routes data is in GitHub only, not in OSM-Wiki
+#
+WIKI_ROUTES_PAGE=""
+
+ANALYSIS_OPTIONS="--check-access --check-bus-stop --check-name --check-osm-separator --check-sequence --check-stop-position --check-version --coloured-sketchline --check-motorway-link --max-error=10 --multiple-ref-type-entries=analyze --positive-notes"
+
+# --language=en
+# --check-bus-stop 
+# --expect-network-short
+# --expect-network-long
+# --expect-network-short-for=
+# --expect-network-long-for=
+# --relaxed-begin-end-for=
+
+    

--- a/FR-IDF-tam/FR-IDF-tam-Routes.txt
+++ b/FR-IDF-tam/FR-IDF-tam-Routes.txt
@@ -1,0 +1,65 @@
+
+#
+# This data is *not* stored in the OSM Wiki but in GitHub 
+#
+# Format: format is like in the OSM Wiki
+#
+# Links: [[...|...]] are interne link like in the OSM Wiki
+#        [... ...] are external links
+#
+# Headers start with '=', '==', '===', '====', ... at the beginning of a line
+#
+# Simple text starts with '-' at the beginning of a line.
+#    A single '-' at the beginning of a line, followed by nothing:
+#    - if there was simple text before, it creates a line feed (i.e. encloses the text in a paragraph <p> ... </p>)
+#    - if there was no simple text before or a line feed, it creates an empty line (i.e. <p>&amp;nbsp;</p>)
+#
+# !!!Text yellow background!!! in simple text or headers
+# '''''Text mit bold and italics''''' in simple text or headers
+# '''Text with bold chars''' in simple text or headers
+# ''Text with italic chars'' in simple text or headers
+#
+# Comments start with '#' at the beginning of a line. '#' inside text is not recognized as the start of a comment, i.e.. '#' may occur inside of text.
+#
+# Format of the file: UTF-8
+#
+#
+# Contents in CSV-Format - if ';' is part of the field, then enclose that field in "..."
+#
+# ref;type;comment;from;to;operator
+#
+# - ref       == tag 'ref' of route or route_master
+#                250            defines that routes with 'ref'='250' are expected
+#                250|250a|250b  defines that routes with 'ref'='250' or 'ref'='250a' or 'ref'='250b' are expected - independent of whether this is allowed according to PTv1/PTv2
+# - type      == contents of tags 'route' respectively 'route_master'
+# - comment   == can include comments like; Bus, Expressbus, ...  will not be analyzed, but simply be printed out
+#                !Text with yellow background! in comment (surrounded by single !)
+# - from      == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - to        == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - operator  == if there is more than one entry with "ref;type", then "operator" is used to distinguish between same line number in different cities/villages
+#
+
+
+= Overview on '''TAM''' Public Transport Lines
+
+-
+- '''!!!This summary is a list of what has been published in open data by Île-de-France Mobilités and found in OSM!!!'''
+-
+- Feel free to modify the list on github
+-
+#
+#ref;type;comment;from;to;operator
+
+== Lines
+A;bus;;;;
+C;bus;;;;
+D;bus;;;;
+E;bus;;;;
+F;bus;;;;
+G;bus;;;;
+I;bus;;;;
+J;bus;;;;
+K;bus;;;;
+M;bus;;;;
+X;bus;;;;
+Z;bus;;;;

--- a/FR-IDF-tam/settings.sh
+++ b/FR-IDF-tam/settings.sh
@@ -1,0 +1,31 @@
+
+#!/bin/bash
+
+#
+# set variales for analysis of network
+#
+
+PREFIX="FR-IDF-tam"
+
+OVERPASS_QUERY="http://overpass-api.de/api/interpreter?data=area[wikidata=Q13917][type=boundary];(rel(area)[route~'bus'];rel(br);rel[type='route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r.routes);node(r.routes););out;"
+NETWORK_LONG=""
+NETWORK_SHORT="TAM"
+
+ANALYSIS_PAGE=""
+ANALYSIS_TALK=""
+#
+# Routes data is in GitHub only, not in OSM-Wiki
+#
+WIKI_ROUTES_PAGE=""
+
+ANALYSIS_OPTIONS="--check-access --check-bus-stop --check-name --check-osm-separator --check-sequence --check-stop-position --check-version --coloured-sketchline --check-motorway-link --max-error=10 --multiple-ref-type-entries=analyze --positive-notes"
+
+# --language=en
+# --check-bus-stop 
+# --expect-network-short
+# --expect-network-long
+# --expect-network-short-for=
+# --expect-network-long-for=
+# --relaxed-begin-end-for=
+
+    

--- a/FR-IDF-tice/FR-IDF-tice-Routes.txt
+++ b/FR-IDF-tice/FR-IDF-tice-Routes.txt
@@ -1,0 +1,77 @@
+
+#
+# This data is *not* stored in the OSM Wiki but in GitHub 
+#
+# Format: format is like in the OSM Wiki
+#
+# Links: [[...|...]] are interne link like in the OSM Wiki
+#        [... ...] are external links
+#
+# Headers start with '=', '==', '===', '====', ... at the beginning of a line
+#
+# Simple text starts with '-' at the beginning of a line.
+#    A single '-' at the beginning of a line, followed by nothing:
+#    - if there was simple text before, it creates a line feed (i.e. encloses the text in a paragraph <p> ... </p>)
+#    - if there was no simple text before or a line feed, it creates an empty line (i.e. <p>&amp;nbsp;</p>)
+#
+# !!!Text yellow background!!! in simple text or headers
+# '''''Text mit bold and italics''''' in simple text or headers
+# '''Text with bold chars''' in simple text or headers
+# ''Text with italic chars'' in simple text or headers
+#
+# Comments start with '#' at the beginning of a line. '#' inside text is not recognized as the start of a comment, i.e.. '#' may occur inside of text.
+#
+# Format of the file: UTF-8
+#
+#
+# Contents in CSV-Format - if ';' is part of the field, then enclose that field in "..."
+#
+# ref;type;comment;from;to;operator
+#
+# - ref       == tag 'ref' of route or route_master
+#                250            defines that routes with 'ref'='250' are expected
+#                250|250a|250b  defines that routes with 'ref'='250' or 'ref'='250a' or 'ref'='250b' are expected - independent of whether this is allowed according to PTv1/PTv2
+# - type      == contents of tags 'route' respectively 'route_master'
+# - comment   == can include comments like; Bus, Expressbus, ...  will not be analyzed, but simply be printed out
+#                !Text with yellow background! in comment (surrounded by single !)
+# - from      == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - to        == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - operator  == if there is more than one entry with "ref;type", then "operator" is used to distinguish between same line number in different cities/villages
+#
+
+
+= Overview on '''TICE''' Public Transport Lines
+
+-
+- '''!!!This summary is a list of what has been published in open data by Île-de-France Mobilités and found in OSM!!!'''
+-
+- Feel free to modify the list on github
+-
+#
+#ref;type;comment;from;to;operator
+
+== Lines
+401;bus;;;;
+402;bus;;;;
+403;bus;;;;
+404;bus;;;;
+405;bus;;;;
+406;bus;;;;
+407;bus;;;;
+408;bus;;;;
+409;bus;;;;
+41;bus;;;;
+412;bus;;;;
+413;bus;;;;
+414;bus;;;;
+415;bus;;;;
+416;bus;;;;
+418;bus;;;;
+419;bus;;;;
+42;bus;;;;
+420;bus;;;;
+43;bus;;;;
+44;bus;;;;
+45;bus;;;;
+453;bus;;;;
+510;bus;;;;

--- a/FR-IDF-tice/settings.sh
+++ b/FR-IDF-tice/settings.sh
@@ -1,0 +1,31 @@
+
+#!/bin/bash
+
+#
+# set variales for analysis of network
+#
+
+PREFIX="FR-IDF-tice"
+
+OVERPASS_QUERY="http://overpass-api.de/api/interpreter?data=area[wikidata=Q13917][type=boundary];(rel(area)[route~'bus'];rel(br);rel[type='route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r.routes);node(r.routes););out;"
+NETWORK_LONG=""
+NETWORK_SHORT="TICE"
+
+ANALYSIS_PAGE=""
+ANALYSIS_TALK=""
+#
+# Routes data is in GitHub only, not in OSM-Wiki
+#
+WIKI_ROUTES_PAGE=""
+
+ANALYSIS_OPTIONS="--check-access --check-bus-stop --check-name --check-osm-separator --check-sequence --check-stop-position --check-version --coloured-sketchline --check-motorway-link --max-error=10 --multiple-ref-type-entries=analyze --positive-notes"
+
+# --language=en
+# --check-bus-stop 
+# --expect-network-short
+# --expect-network-long
+# --expect-network-short-for=
+# --expect-network-long-for=
+# --relaxed-begin-end-for=
+
+    

--- a/FR-IDF-tramy/FR-IDF-tramy-Routes.txt
+++ b/FR-IDF-tramy/FR-IDF-tramy-Routes.txt
@@ -1,0 +1,85 @@
+
+#
+# This data is *not* stored in the OSM Wiki but in GitHub 
+#
+# Format: format is like in the OSM Wiki
+#
+# Links: [[...|...]] are interne link like in the OSM Wiki
+#        [... ...] are external links
+#
+# Headers start with '=', '==', '===', '====', ... at the beginning of a line
+#
+# Simple text starts with '-' at the beginning of a line.
+#    A single '-' at the beginning of a line, followed by nothing:
+#    - if there was simple text before, it creates a line feed (i.e. encloses the text in a paragraph <p> ... </p>)
+#    - if there was no simple text before or a line feed, it creates an empty line (i.e. <p>&amp;nbsp;</p>)
+#
+# !!!Text yellow background!!! in simple text or headers
+# '''''Text mit bold and italics''''' in simple text or headers
+# '''Text with bold chars''' in simple text or headers
+# ''Text with italic chars'' in simple text or headers
+#
+# Comments start with '#' at the beginning of a line. '#' inside text is not recognized as the start of a comment, i.e.. '#' may occur inside of text.
+#
+# Format of the file: UTF-8
+#
+#
+# Contents in CSV-Format - if ';' is part of the field, then enclose that field in "..."
+#
+# ref;type;comment;from;to;operator
+#
+# - ref       == tag 'ref' of route or route_master
+#                250            defines that routes with 'ref'='250' are expected
+#                250|250a|250b  defines that routes with 'ref'='250' or 'ref'='250a' or 'ref'='250b' are expected - independent of whether this is allowed according to PTv1/PTv2
+# - type      == contents of tags 'route' respectively 'route_master'
+# - comment   == can include comments like; Bus, Expressbus, ...  will not be analyzed, but simply be printed out
+#                !Text with yellow background! in comment (surrounded by single !)
+# - from      == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - to        == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - operator  == if there is more than one entry with "ref;type", then "operator" is used to distinguish between same line number in different cities/villages
+#
+
+
+= Overview on '''TRAMY''' Public Transport Lines
+
+-
+- '''!!!This summary is a list of what has been published in open data by Île-de-France Mobilités and found in OSM!!!'''
+-
+- Feel free to modify the list on github
+-
+#
+#ref;type;comment;from;to;operator
+
+== Lines
+02A;bus;;;;
+02B;bus;;;;
+02C;bus;;;;
+02D;bus;;;;
+02E;bus;;;;
+02F;bus;;;;
+03A;bus;;;;
+03B;bus;;;;
+03C;bus;;;;
+09A;bus;;;;
+09B;bus;;;;
+09C;bus;;;;
+09M;bus;;;;
+10;bus;;;;
+12A;bus;;;;
+12B;bus;;;;
+12C;bus;;;;
+25;bus;;;;
+26;bus;;;;
+27;bus;;;;
+29A;bus;;;;
+29B;bus;;;;
+29M;bus;;;;
+31A;bus;;;;
+31B;bus;;;;
+31C;bus;;;;
+38;bus;;;;
+39;bus;;;;
+42;bus;;;;
+A;bus;;;;
+B;bus;;;;
+D;bus;;;;

--- a/FR-IDF-tramy/settings.sh
+++ b/FR-IDF-tramy/settings.sh
@@ -1,0 +1,31 @@
+
+#!/bin/bash
+
+#
+# set variales for analysis of network
+#
+
+PREFIX="FR-IDF-tramy"
+
+OVERPASS_QUERY="http://overpass-api.de/api/interpreter?data=area[wikidata=Q13917][type=boundary];(rel(area)[route~'bus'];rel(br);rel[type='route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r.routes);node(r.routes););out;"
+NETWORK_LONG=""
+NETWORK_SHORT="TRAMY"
+
+ANALYSIS_PAGE=""
+ANALYSIS_TALK=""
+#
+# Routes data is in GitHub only, not in OSM-Wiki
+#
+WIKI_ROUTES_PAGE=""
+
+ANALYSIS_OPTIONS="--check-access --check-bus-stop --check-name --check-osm-separator --check-sequence --check-stop-position --check-version --coloured-sketchline --check-motorway-link --max-error=10 --multiple-ref-type-entries=analyze --positive-notes"
+
+# --language=en
+# --check-bus-stop 
+# --expect-network-short
+# --expect-network-long
+# --expect-network-short-for=
+# --expect-network-long-for=
+# --relaxed-begin-end-for=
+
+    

--- a/FR-IDF-trans-essonne/FR-IDF-trans-essonne-Routes.txt
+++ b/FR-IDF-trans-essonne/FR-IDF-trans-essonne-Routes.txt
@@ -1,0 +1,64 @@
+
+#
+# This data is *not* stored in the OSM Wiki but in GitHub 
+#
+# Format: format is like in the OSM Wiki
+#
+# Links: [[...|...]] are interne link like in the OSM Wiki
+#        [... ...] are external links
+#
+# Headers start with '=', '==', '===', '====', ... at the beginning of a line
+#
+# Simple text starts with '-' at the beginning of a line.
+#    A single '-' at the beginning of a line, followed by nothing:
+#    - if there was simple text before, it creates a line feed (i.e. encloses the text in a paragraph <p> ... </p>)
+#    - if there was no simple text before or a line feed, it creates an empty line (i.e. <p>&amp;nbsp;</p>)
+#
+# !!!Text yellow background!!! in simple text or headers
+# '''''Text mit bold and italics''''' in simple text or headers
+# '''Text with bold chars''' in simple text or headers
+# ''Text with italic chars'' in simple text or headers
+#
+# Comments start with '#' at the beginning of a line. '#' inside text is not recognized as the start of a comment, i.e.. '#' may occur inside of text.
+#
+# Format of the file: UTF-8
+#
+#
+# Contents in CSV-Format - if ';' is part of the field, then enclose that field in "..."
+#
+# ref;type;comment;from;to;operator
+#
+# - ref       == tag 'ref' of route or route_master
+#                250            defines that routes with 'ref'='250' are expected
+#                250|250a|250b  defines that routes with 'ref'='250' or 'ref'='250a' or 'ref'='250b' are expected - independent of whether this is allowed according to PTv1/PTv2
+# - type      == contents of tags 'route' respectively 'route_master'
+# - comment   == can include comments like; Bus, Expressbus, ...  will not be analyzed, but simply be printed out
+#                !Text with yellow background! in comment (surrounded by single !)
+# - from      == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - to        == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - operator  == if there is more than one entry with "ref;type", then "operator" is used to distinguish between same line number in different cities/villages
+#
+
+
+= Overview on '''Trans'Essonne''' Public Transport Lines
+
+-
+- '''!!!This summary is a list of what has been published in open data by Île-de-France Mobilités and found in OSM!!!'''
+-
+- Feel free to modify the list on github
+-
+#
+#ref;type;comment;from;to;operator
+
+== Lines
+207;bus;;;;
+208;bus;;;;
+209;bus;;;;
+227;bus;;;;
+228;bus;;;;
+229;bus;;;;
+230;bus;;;;
+231;bus;;;;
+24-06;bus;;;;
+24-10;bus;;;;
+FLEXO;bus;;;;

--- a/FR-IDF-trans-essonne/settings.sh
+++ b/FR-IDF-trans-essonne/settings.sh
@@ -1,0 +1,31 @@
+
+#!/bin/bash
+
+#
+# set variales for analysis of network
+#
+
+PREFIX="FR-IDF-trans-essonne"
+
+OVERPASS_QUERY="http://overpass-api.de/api/interpreter?data=area[wikidata=Q13917][type=boundary];(rel(area)[route~'bus'];rel(br);rel[type='route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r.routes);node(r.routes););out;"
+NETWORK_LONG=""
+NETWORK_SHORT="Trans'Essonne"
+
+ANALYSIS_PAGE=""
+ANALYSIS_TALK=""
+#
+# Routes data is in GitHub only, not in OSM-Wiki
+#
+WIKI_ROUTES_PAGE=""
+
+ANALYSIS_OPTIONS="--check-access --check-bus-stop --check-name --check-osm-separator --check-sequence --check-stop-position --check-version --coloured-sketchline --check-motorway-link --max-error=10 --multiple-ref-type-entries=analyze --positive-notes"
+
+# --language=en
+# --check-bus-stop 
+# --expect-network-short
+# --expect-network-long
+# --expect-network-short-for=
+# --expect-network-long-for=
+# --relaxed-begin-end-for=
+
+    

--- a/FR-IDF-transdev-ile-de-france-conflans/FR-IDF-transdev-ile-de-france-conflans-Routes.txt
+++ b/FR-IDF-transdev-ile-de-france-conflans/FR-IDF-transdev-ile-de-france-conflans-Routes.txt
@@ -1,0 +1,67 @@
+
+#
+# This data is *not* stored in the OSM Wiki but in GitHub 
+#
+# Format: format is like in the OSM Wiki
+#
+# Links: [[...|...]] are interne link like in the OSM Wiki
+#        [... ...] are external links
+#
+# Headers start with '=', '==', '===', '====', ... at the beginning of a line
+#
+# Simple text starts with '-' at the beginning of a line.
+#    A single '-' at the beginning of a line, followed by nothing:
+#    - if there was simple text before, it creates a line feed (i.e. encloses the text in a paragraph <p> ... </p>)
+#    - if there was no simple text before or a line feed, it creates an empty line (i.e. <p>&amp;nbsp;</p>)
+#
+# !!!Text yellow background!!! in simple text or headers
+# '''''Text mit bold and italics''''' in simple text or headers
+# '''Text with bold chars''' in simple text or headers
+# ''Text with italic chars'' in simple text or headers
+#
+# Comments start with '#' at the beginning of a line. '#' inside text is not recognized as the start of a comment, i.e.. '#' may occur inside of text.
+#
+# Format of the file: UTF-8
+#
+#
+# Contents in CSV-Format - if ';' is part of the field, then enclose that field in "..."
+#
+# ref;type;comment;from;to;operator
+#
+# - ref       == tag 'ref' of route or route_master
+#                250            defines that routes with 'ref'='250' are expected
+#                250|250a|250b  defines that routes with 'ref'='250' or 'ref'='250a' or 'ref'='250b' are expected - independent of whether this is allowed according to PTv1/PTv2
+# - type      == contents of tags 'route' respectively 'route_master'
+# - comment   == can include comments like; Bus, Expressbus, ...  will not be analyzed, but simply be printed out
+#                !Text with yellow background! in comment (surrounded by single !)
+# - from      == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - to        == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - operator  == if there is more than one entry with "ref;type", then "operator" is used to distinguish between same line number in different cities/villages
+#
+
+
+= Overview on '''Transdev Ile-de-France Conflans''' Public Transport Lines
+
+-
+- '''!!!This summary is a list of what has been published in open data by Île-de-France Mobilités and found in OSM!!!'''
+-
+- Feel free to modify the list on github
+-
+#
+#ref;type;comment;from;to;operator
+
+== Lines
+02;bus;;;;
+04;bus;;;;
+05;bus;;;;
+06;bus;;;;
+11;bus;;;;
+12;bus;;;;
+14;bus;;;;
+17A;bus;;;;
+17B;bus;;;;
+27;bus;;;;
+5 S;bus;;;;
+9518;bus;;;;
+A1;bus;;;;
+A2;bus;;;;

--- a/FR-IDF-transdev-ile-de-france-conflans/settings.sh
+++ b/FR-IDF-transdev-ile-de-france-conflans/settings.sh
@@ -1,0 +1,31 @@
+
+#!/bin/bash
+
+#
+# set variales for analysis of network
+#
+
+PREFIX="FR-IDF-transdev-ile-de-france-conflans"
+
+OVERPASS_QUERY="http://overpass-api.de/api/interpreter?data=area[wikidata=Q13917][type=boundary];(rel(area)[route~'bus'];rel(br);rel[type='route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r.routes);node(r.routes););out;"
+NETWORK_LONG=""
+NETWORK_SHORT="Transdev Ile-de-France Conflans"
+
+ANALYSIS_PAGE=""
+ANALYSIS_TALK=""
+#
+# Routes data is in GitHub only, not in OSM-Wiki
+#
+WIKI_ROUTES_PAGE=""
+
+ANALYSIS_OPTIONS="--check-access --check-bus-stop --check-name --check-osm-separator --check-sequence --check-stop-position --check-version --coloured-sketchline --check-motorway-link --max-error=10 --multiple-ref-type-entries=analyze --positive-notes"
+
+# --language=en
+# --check-bus-stop 
+# --expect-network-short
+# --expect-network-long
+# --expect-network-short-for=
+# --expect-network-long-for=
+# --relaxed-begin-end-for=
+
+    

--- a/FR-IDF-transports-daniel-meyer/FR-IDF-transports-daniel-meyer-Routes.txt
+++ b/FR-IDF-transports-daniel-meyer/FR-IDF-transports-daniel-meyer-Routes.txt
@@ -1,0 +1,84 @@
+
+#
+# This data is *not* stored in the OSM Wiki but in GitHub 
+#
+# Format: format is like in the OSM Wiki
+#
+# Links: [[...|...]] are interne link like in the OSM Wiki
+#        [... ...] are external links
+#
+# Headers start with '=', '==', '===', '====', ... at the beginning of a line
+#
+# Simple text starts with '-' at the beginning of a line.
+#    A single '-' at the beginning of a line, followed by nothing:
+#    - if there was simple text before, it creates a line feed (i.e. encloses the text in a paragraph <p> ... </p>)
+#    - if there was no simple text before or a line feed, it creates an empty line (i.e. <p>&amp;nbsp;</p>)
+#
+# !!!Text yellow background!!! in simple text or headers
+# '''''Text mit bold and italics''''' in simple text or headers
+# '''Text with bold chars''' in simple text or headers
+# ''Text with italic chars'' in simple text or headers
+#
+# Comments start with '#' at the beginning of a line. '#' inside text is not recognized as the start of a comment, i.e.. '#' may occur inside of text.
+#
+# Format of the file: UTF-8
+#
+#
+# Contents in CSV-Format - if ';' is part of the field, then enclose that field in "..."
+#
+# ref;type;comment;from;to;operator
+#
+# - ref       == tag 'ref' of route or route_master
+#                250            defines that routes with 'ref'='250' are expected
+#                250|250a|250b  defines that routes with 'ref'='250' or 'ref'='250a' or 'ref'='250b' are expected - independent of whether this is allowed according to PTv1/PTv2
+# - type      == contents of tags 'route' respectively 'route_master'
+# - comment   == can include comments like; Bus, Expressbus, ...  will not be analyzed, but simply be printed out
+#                !Text with yellow background! in comment (surrounded by single !)
+# - from      == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - to        == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - operator  == if there is more than one entry with "ref;type", then "operator" is used to distinguish between same line number in different cities/villages
+#
+
+
+= Overview on '''TRANSPORTS DANIEL MEYER''' Public Transport Lines
+
+-
+- '''!!!This summary is a list of what has been published in open data by Île-de-France Mobilités and found in OSM!!!'''
+-
+- Feel free to modify the list on github
+-
+#
+#ref;type;comment;from;to;operator
+
+== Lines
+DM02 A;bus;;;;
+DM02 B;bus;;;;
+DM03;bus;;;;
+DM04;bus;;;;
+DM05;bus;;;;
+DM06 A;bus;;;;
+DM06 B;bus;;;;
+DM08;bus;;;;
+DM09;bus;;;;
+DM10 A;bus;;;;
+DM10 S;bus;;;;
+DM11 A;bus;;;;
+DM11 C;bus;;;;
+DM11E;bus;;;;
+DM11G;bus;;;;
+DM12;bus;;;;
+DM13;bus;;;;
+DM151;bus;;;;
+DM153;bus;;;;
+DM16;bus;;;;
+DM17 A;bus;;;;
+DM17 B;bus;;;;
+DM17 S;bus;;;;
+DM19;bus;;;;
+DM20;bus;;;;
+DM20 S;bus;;;;
+DM21 A;bus;;;;
+DM21 B;bus;;;;
+DM21 S;bus;;;;
+DM22;bus;;;;
+DM26;bus;;;;

--- a/FR-IDF-transports-daniel-meyer/settings.sh
+++ b/FR-IDF-transports-daniel-meyer/settings.sh
@@ -1,0 +1,31 @@
+
+#!/bin/bash
+
+#
+# set variales for analysis of network
+#
+
+PREFIX="FR-IDF-transports-daniel-meyer"
+
+OVERPASS_QUERY="http://overpass-api.de/api/interpreter?data=area[wikidata=Q13917][type=boundary];(rel(area)[route~'bus'];rel(br);rel[type='route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r.routes);node(r.routes););out;"
+NETWORK_LONG=""
+NETWORK_SHORT="TRANSPORTS DANIEL MEYER"
+
+ANALYSIS_PAGE=""
+ANALYSIS_TALK=""
+#
+# Routes data is in GitHub only, not in OSM-Wiki
+#
+WIKI_ROUTES_PAGE=""
+
+ANALYSIS_OPTIONS="--check-access --check-bus-stop --check-name --check-osm-separator --check-sequence --check-stop-position --check-version --coloured-sketchline --check-motorway-link --max-error=10 --multiple-ref-type-entries=analyze --positive-notes"
+
+# --language=en
+# --check-bus-stop 
+# --expect-network-short
+# --expect-network-long
+# --expect-network-short-for=
+# --expect-network-long-for=
+# --relaxed-begin-end-for=
+
+    

--- a/FR-IDF-val-de-seine/FR-IDF-val-de-seine-Routes.txt
+++ b/FR-IDF-val-de-seine/FR-IDF-val-de-seine-Routes.txt
@@ -1,0 +1,84 @@
+
+#
+# This data is *not* stored in the OSM Wiki but in GitHub 
+#
+# Format: format is like in the OSM Wiki
+#
+# Links: [[...|...]] are interne link like in the OSM Wiki
+#        [... ...] are external links
+#
+# Headers start with '=', '==', '===', '====', ... at the beginning of a line
+#
+# Simple text starts with '-' at the beginning of a line.
+#    A single '-' at the beginning of a line, followed by nothing:
+#    - if there was simple text before, it creates a line feed (i.e. encloses the text in a paragraph <p> ... </p>)
+#    - if there was no simple text before or a line feed, it creates an empty line (i.e. <p>&amp;nbsp;</p>)
+#
+# !!!Text yellow background!!! in simple text or headers
+# '''''Text mit bold and italics''''' in simple text or headers
+# '''Text with bold chars''' in simple text or headers
+# ''Text with italic chars'' in simple text or headers
+#
+# Comments start with '#' at the beginning of a line. '#' inside text is not recognized as the start of a comment, i.e.. '#' may occur inside of text.
+#
+# Format of the file: UTF-8
+#
+#
+# Contents in CSV-Format - if ';' is part of the field, then enclose that field in "..."
+#
+# ref;type;comment;from;to;operator
+#
+# - ref       == tag 'ref' of route or route_master
+#                250            defines that routes with 'ref'='250' are expected
+#                250|250a|250b  defines that routes with 'ref'='250' or 'ref'='250a' or 'ref'='250b' are expected - independent of whether this is allowed according to PTv1/PTv2
+# - type      == contents of tags 'route' respectively 'route_master'
+# - comment   == can include comments like; Bus, Expressbus, ...  will not be analyzed, but simply be printed out
+#                !Text with yellow background! in comment (surrounded by single !)
+# - from      == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - to        == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - operator  == if there is more than one entry with "ref;type", then "operator" is used to distinguish between same line number in different cities/villages
+#
+
+
+= Overview on '''Val de Seine''' Public Transport Lines
+
+-
+- '''!!!This summary is a list of what has been published in open data by Île-de-France Mobilités and found in OSM!!!'''
+-
+- Feel free to modify the list on github
+-
+#
+#ref;type;comment;from;to;operator
+
+== Lines
+10;bus;;;;
+12;bus;;;;
+13;bus;;;;
+14;bus;;;;
+17;bus;;;;
+170;bus;;;;
+171;bus;;;;
+172;bus;;;;
+17S;bus;;;;
+18;bus;;;;
+19;bus;;;;
+2;bus;;;;
+21;bus;;;;
+311;bus;;;;
+312;bus;;;;
+313;bus;;;;
+32;bus;;;;
+33;bus;;;;
+34;bus;;;;
+41;bus;;;;
+42;bus;;;;
+43;bus;;;;
+5;bus;;;;
+502;bus;;;;
+511;bus;;;;
+512;bus;;;;
+71;bus;;;;
+75;bus;;;;
+76;bus;;;;
+77;bus;;;;
+9;bus;;;;

--- a/FR-IDF-val-de-seine/settings.sh
+++ b/FR-IDF-val-de-seine/settings.sh
@@ -1,0 +1,31 @@
+
+#!/bin/bash
+
+#
+# set variales for analysis of network
+#
+
+PREFIX="FR-IDF-val-de-seine"
+
+OVERPASS_QUERY="http://overpass-api.de/api/interpreter?data=area[wikidata=Q13917][type=boundary];(rel(area)[route~'bus'];rel(br);rel[type='route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r.routes);node(r.routes););out;"
+NETWORK_LONG=""
+NETWORK_SHORT="Val de Seine"
+
+ANALYSIS_PAGE=""
+ANALYSIS_TALK=""
+#
+# Routes data is in GitHub only, not in OSM-Wiki
+#
+WIKI_ROUTES_PAGE=""
+
+ANALYSIS_OPTIONS="--check-access --check-bus-stop --check-name --check-osm-separator --check-sequence --check-stop-position --check-version --coloured-sketchline --check-motorway-link --max-error=10 --multiple-ref-type-entries=analyze --positive-notes"
+
+# --language=en
+# --check-bus-stop 
+# --expect-network-short
+# --expect-network-long
+# --expect-network-short-for=
+# --expect-network-long-for=
+# --relaxed-begin-end-for=
+
+    

--- a/FR-IDF-vybus/FR-IDF-vybus-Routes.txt
+++ b/FR-IDF-vybus/FR-IDF-vybus-Routes.txt
@@ -1,0 +1,74 @@
+
+#
+# This data is *not* stored in the OSM Wiki but in GitHub 
+#
+# Format: format is like in the OSM Wiki
+#
+# Links: [[...|...]] are interne link like in the OSM Wiki
+#        [... ...] are external links
+#
+# Headers start with '=', '==', '===', '====', ... at the beginning of a line
+#
+# Simple text starts with '-' at the beginning of a line.
+#    A single '-' at the beginning of a line, followed by nothing:
+#    - if there was simple text before, it creates a line feed (i.e. encloses the text in a paragraph <p> ... </p>)
+#    - if there was no simple text before or a line feed, it creates an empty line (i.e. <p>&amp;nbsp;</p>)
+#
+# !!!Text yellow background!!! in simple text or headers
+# '''''Text mit bold and italics''''' in simple text or headers
+# '''Text with bold chars''' in simple text or headers
+# ''Text with italic chars'' in simple text or headers
+#
+# Comments start with '#' at the beginning of a line. '#' inside text is not recognized as the start of a comment, i.e.. '#' may occur inside of text.
+#
+# Format of the file: UTF-8
+#
+#
+# Contents in CSV-Format - if ';' is part of the field, then enclose that field in "..."
+#
+# ref;type;comment;from;to;operator
+#
+# - ref       == tag 'ref' of route or route_master
+#                250            defines that routes with 'ref'='250' are expected
+#                250|250a|250b  defines that routes with 'ref'='250' or 'ref'='250a' or 'ref'='250b' are expected - independent of whether this is allowed according to PTv1/PTv2
+# - type      == contents of tags 'route' respectively 'route_master'
+# - comment   == can include comments like; Bus, Expressbus, ...  will not be analyzed, but simply be printed out
+#                !Text with yellow background! in comment (surrounded by single !)
+# - from      == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - to        == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - operator  == if there is more than one entry with "ref;type", then "operator" is used to distinguish between same line number in different cities/villages
+#
+
+
+= Overview on '''VyBus''' Public Transport Lines
+
+-
+- '''!!!This summary is a list of what has been published in open data by Île-de-France Mobilités and found in OSM!!!'''
+-
+- Feel free to modify the list on github
+-
+#
+#ref;type;comment;from;to;operator
+
+== Lines
+A;bus;;;;
+C;bus;;;;
+D;bus;;;;
+E;bus;;;;
+E1;bus;;;;
+E2;bus;;;;
+F;bus;;;;
+F4;bus;;;;
+G1;bus;;;;
+G2;bus;;;;
+H;bus;;;;
+I;bus;;;;
+M;bus;;;;
+QBUS;bus;;;;
+R1;bus;;;;
+R1A;bus;;;;
+R1B;bus;;;;
+R2;bus;;;;
+R3;bus;;;;
+S;bus;;;;
+X;bus;;;;

--- a/FR-IDF-vybus/settings.sh
+++ b/FR-IDF-vybus/settings.sh
@@ -1,0 +1,31 @@
+
+#!/bin/bash
+
+#
+# set variales for analysis of network
+#
+
+PREFIX="FR-IDF-vybus"
+
+OVERPASS_QUERY="http://overpass-api.de/api/interpreter?data=area[wikidata=Q13917][type=boundary];(rel(area)[route~'bus'];rel(br);rel[type='route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r.routes);node(r.routes););out;"
+NETWORK_LONG=""
+NETWORK_SHORT="VyBus"
+
+ANALYSIS_PAGE=""
+ANALYSIS_TALK=""
+#
+# Routes data is in GitHub only, not in OSM-Wiki
+#
+WIKI_ROUTES_PAGE=""
+
+ANALYSIS_OPTIONS="--check-access --check-bus-stop --check-name --check-osm-separator --check-sequence --check-stop-position --check-version --coloured-sketchline --check-motorway-link --max-error=10 --multiple-ref-type-entries=analyze --positive-notes"
+
+# --language=en
+# --check-bus-stop 
+# --expect-network-short
+# --expect-network-long
+# --expect-network-short-for=
+# --expect-network-long-for=
+# --relaxed-begin-end-for=
+
+    

--- a/FR-IDF-yerres/FR-IDF-yerres-Routes.txt
+++ b/FR-IDF-yerres/FR-IDF-yerres-Routes.txt
@@ -1,0 +1,69 @@
+
+#
+# This data is *not* stored in the OSM Wiki but in GitHub 
+#
+# Format: format is like in the OSM Wiki
+#
+# Links: [[...|...]] are interne link like in the OSM Wiki
+#        [... ...] are external links
+#
+# Headers start with '=', '==', '===', '====', ... at the beginning of a line
+#
+# Simple text starts with '-' at the beginning of a line.
+#    A single '-' at the beginning of a line, followed by nothing:
+#    - if there was simple text before, it creates a line feed (i.e. encloses the text in a paragraph <p> ... </p>)
+#    - if there was no simple text before or a line feed, it creates an empty line (i.e. <p>&amp;nbsp;</p>)
+#
+# !!!Text yellow background!!! in simple text or headers
+# '''''Text mit bold and italics''''' in simple text or headers
+# '''Text with bold chars''' in simple text or headers
+# ''Text with italic chars'' in simple text or headers
+#
+# Comments start with '#' at the beginning of a line. '#' inside text is not recognized as the start of a comment, i.e.. '#' may occur inside of text.
+#
+# Format of the file: UTF-8
+#
+#
+# Contents in CSV-Format - if ';' is part of the field, then enclose that field in "..."
+#
+# ref;type;comment;from;to;operator
+#
+# - ref       == tag 'ref' of route or route_master
+#                250            defines that routes with 'ref'='250' are expected
+#                250|250a|250b  defines that routes with 'ref'='250' or 'ref'='250a' or 'ref'='250b' are expected - independent of whether this is allowed according to PTv1/PTv2
+# - type      == contents of tags 'route' respectively 'route_master'
+# - comment   == can include comments like; Bus, Expressbus, ...  will not be analyzed, but simply be printed out
+#                !Text with yellow background! in comment (surrounded by single !)
+# - from      == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - to        == if there is more than one entry with "ref;type" and "operator" is the same, then 'from' and 'to are also used to distinguish between same line number in different cities/villages
+# - operator  == if there is more than one entry with "ref;type", then "operator" is used to distinguish between same line number in different cities/villages
+#
+
+
+= Overview on '''Yerres''' Public Transport Lines
+
+-
+- '''!!!This summary is a list of what has been published in open data by Île-de-France Mobilités and found in OSM!!!'''
+-
+- Feel free to modify the list on github
+-
+#
+#ref;type;comment;from;to;operator
+
+== Lines
+04;bus;;;;
+14;bus;;;;
+20;bus;;;;
+23;bus;;;;
+24;bus;;;;
+32;bus;;;;
+34A;bus;;;;
+34B;bus;;;;
+35A;bus;;;;
+35B;bus;;;;
+35C;bus;;;;
+35D;bus;;;;
+37A;bus;;;;
+37B;bus;;;;
+37C;bus;;;;
+37RPI;bus;;;;

--- a/FR-IDF-yerres/settings.sh
+++ b/FR-IDF-yerres/settings.sh
@@ -1,0 +1,31 @@
+
+#!/bin/bash
+
+#
+# set variales for analysis of network
+#
+
+PREFIX="FR-IDF-yerres"
+
+OVERPASS_QUERY="http://overpass-api.de/api/interpreter?data=area[wikidata=Q13917][type=boundary];(rel(area)[route~'bus'];rel(br);rel[type='route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r.routes);node(r.routes););out;"
+NETWORK_LONG=""
+NETWORK_SHORT="Yerres"
+
+ANALYSIS_PAGE=""
+ANALYSIS_TALK=""
+#
+# Routes data is in GitHub only, not in OSM-Wiki
+#
+WIKI_ROUTES_PAGE=""
+
+ANALYSIS_OPTIONS="--check-access --check-bus-stop --check-name --check-osm-separator --check-sequence --check-stop-position --check-version --coloured-sketchline --check-motorway-link --max-error=10 --multiple-ref-type-entries=analyze --positive-notes"
+
+# --language=en
+# --check-bus-stop 
+# --expect-network-short
+# --expect-network-long
+# --expect-network-short-for=
+# --expect-network-long-for=
+# --relaxed-begin-end-for=
+
+    


### PR DESCRIPTION
Here are the bus networks in Île-de-France region that have at least 10 lines, according to the `Île-de-France Mobilités` open data.