### PR TITLE
Remove "Verbundtarif Region Braunschweig" from the list of valid names

### DIFF
--- a/UTC+01/DE/NI/DE-NI-VRB/settings.sh
+++ b/UTC+01/DE/NI/DE-NI-VRB/settings.sh
@@ -7,7 +7,7 @@
 PREFIX="DE-NI-VRB"
 
 OVERPASS_QUERY="http://overpass-api.de/api/interpreter?data=area[boundary=public_transport][name='Verkehrsverbund Region Braunschweig'];(rel(area)[route~'(bus|tram|train|subway|light_rail|trolleybus|ferry|monorail|aerialway|share_taxi|funicular)'];rel(br);rel[type='route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r);node(w);way(r.routes);node(w);node(r.routes););out;"
-NETWORK_LONG="Verkehrsverbund Region Braunschweig|Verbundtarif Region Braunschweig|Verbundtarif Region Braunschweig (VRB)"
+NETWORK_LONG="Verkehrsverbund Region Braunschweig"
 NETWORK_SHORT="VRB"
 
 ANALYSIS_PAGE="Verkehrsverbund_Region_Braunschweig/Analyse"


### PR DESCRIPTION
I finally found the time to remove all occurrences of `network=Verbundtarif Region Braunschweig` as well as `network=Verbundtarif Region Braunschweig (VRB)` in the current OSM data. This was the name of the network until December 2016, when the name of the network changed to "Verkehrsverbund Region Braunschweig". As this is the preferred name, PTNA should also be able to recognize if the old one is used 😏