### PR TITLE
Add BEG network

### DIFF
--- a/UTC+01/DE/BY/DE-BY-INVG/settings.sh
+++ b/UTC+01/DE/BY/DE-BY-INVG/settings.sh
@@ -6,9 +6,9 @@
 
 PREFIX="DE-BY-INVG"
 
-OVERPASS_QUERY="http://overpass-api.de/api/interpreter?data=area[boundary=administrative][admin_level=6][name~'(Ingolstadt|Landkreis Eichstätt)'];(rel(area)[route~'(bus|tram|train|subway|light_rail|trolleybus|ferry|monorail|aerialway|share_taxi|funicular)'];rel(br);rel[type='route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r);node(w);way(r.routes);node(w);node(r.routes););out;"
-NETWORK_LONG="Ingolstädter Verkehrsgesellschaft mbH|Verkehrsgemeinschaft Region Ingolstadt"
-NETWORK_SHORT="INVG|VGI"
+OVERPASS_QUERY="http://overpass-api.de/api/interpreter?data=area[boundary=administrative][admin_level=6][name~'Ingolstadt'];(rel(area)[route~'(bus|tram|train|subway|light_rail|trolleybus|ferry|monorail|aerialway|share_taxi|funicular)'];rel(br);rel[type='route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r);node(w);way(r.routes);node(w);node(r.routes););out;"
+NETWORK_LONG="Verkehrsgemeinschaft Region Ingolstadt|Bayerische Eisenbahngesellschaft"
+NETWORK_SHORT="VGI|BEG"
 
 ANALYSIS_PAGE="Ingolstadt/Transportation/Analyse"
 ANALYSIS_TALK="Talk:Ingolstadt/Transportation/Analyse"
@@ -29,11 +29,11 @@ ANALYSIS_OPTIONS="--language=de --check-bus-stop --link-gtfs --show-gtfs --gtfs-
 # automatically build by PHP script
 
 # Name + Link to Overpass-Turbo call to show area on map
-PTNA_WWW_REGION_NAME="Stadt und Landkreis Ingolstadt sowie Landkreis Eichstätt"
-PTNA_WWW_REGION_LINK="http://overpass-turbo.eu/map.html?Q=%5Bout%3Ajson%5D%5Btimeout%3A25%5D%3B(relation%5Bboundary%3Dadministrative%5D%5Badmin_level%3D6%5D%5Bname~%27(Ingolstadt|Landkreis%20Eichst%C3%A4tt)%27%5D%3B)%3Bout%20body%3B%3E%3Bout%20skel%20qt%3B"
+PTNA_WWW_REGION_NAME="Kreisfreie Stadt Ingolstadt"
+PTNA_WWW_REGION_LINK="http://overpass-turbo.eu/map.html?Q=[out%3Ajson][timeout%3A25]%3B(relation[boundary%3Dadministrative][admin_level%3D6][name~%27Ingolstadt%27]%3B)%3Bout%20body%3B%3E%3Bout%20skel%20qt%3B"
 
 # Name + Link to the network provider / transport association
-PTNA_WWW_NETWORK_NAME="Ingolstädter Verkehrsgesellschaft mbH"
+PTNA_WWW_NETWORK_NAME="Verkehrsgemeinschaft Region Ingolstadt"
 PTNA_WWW_NETWORK_LINK="https://www.invg.de/"
 
 # Date and Time of last analysis in UTC and Local Time format


### PR DESCRIPTION
Add the Bayerische Eisenbahngesellschaft in the network to become the train relations. Reduce the region to the city of Ingolstadt alone as we do have the VGI-analysis.