### PR TITLE
Change networks

### DIFF
--- a/UTC+01/DE/BY/DE-BY-VGA/settings.sh
+++ b/UTC+01/DE/BY/DE-BY-VGA/settings.sh
@@ -7,8 +7,8 @@
 PREFIX="DE-BY-VGA"
 
 OVERPASS_QUERY="http://overpass-api.de/api/interpreter?data=area[boundary=administrative][admin_level=6][name='Landkreis Eichstätt'];(rel(area)[route~'(bus|tram|train|subway|light_rail|trolleybus|ferry|monorail|aerialway|share_taxi|funicular)'];rel(br);rel[type='route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r);node(w);way(r.routes);node(w);node(r.routes););out;"
-NETWORK_LONG="Verkehrsgmeinschaft Altmühltal|Jägle Verkehrsbetriebe|Regionalbus Augsburg|Regionalbus Augsburg GmbH|Verkehrsverbund Großraum Nürnberg|Verkehrsverbund Großraum Nürnberg GmbH|Verkehrsgemeinschaft Landkreis Kelheim|Stadtlinie Eichstätt|Sillner|Buchberger Reisen|Verkehrsgemeinschaft Region Ingolstadt"
-NETWORK_SHORT="VGA|JVB|RBA|VGN|VLK|VGI"
+NETWORK_LONG="Verkehrsgmeinschaft Altmühltal|Regionalbus Augsburg|Verkehrsverbund Großraum Nürnberg|Verkehrsgemeinschaft Landkreis Kelheim|Stadtlinie Eichstätt|Sillner|Buchberger Reisen|Verkehrsgemeinschaft Region Ingolstadt||Bayerische Eisenbahngesellschaft"
+NETWORK_SHORT="VGA|RBA|VGN|VLK|VGI|BEG"
 
 ANALYSIS_PAGE="Eichstätt/Transportation/Analyse"
 ANALYSIS_TALK="Talk:Eichstätt/Transportation/Analyse"


### PR DESCRIPTION
Add the Bayerische Eisenbahngesellschaft / BEG in the network to become the train relations. Remove Jägle Verkehrsbetriebe / JVB and Verkehrsverbund Großraum Nürnberg GmbH as the relations have been changed accordingly.