### PR TITLE
Remove option --check-motorway-link

### DIFF
--- a/UTC+01/FR/PAC/FR-PAC-Zou/settings.sh
+++ b/UTC+01/FR/PAC/FR-PAC-Zou/settings.sh
@@ -19,7 +19,7 @@ ANALYSIS_PAGE="Zou_!/Analyse"
 ANALYSIS_TALK="Talk:Zou_!/Analyse"
 WIKI_ROUTES_PAGE="Zou_!/Lignes_Zou"
 
-ANALYSIS_OPTIONS="--language=fr --check-bus-stop --link-gtfs --show-gtfs --gtfs-feed=$PREFIX --max-error=10 --check-access --check-way-type --check-name-relaxed --check-stop-position --check-sequence --check-version --check-osm-separator --check-motorway-link --check-platform --check-roundabouts --expect-network-long --multiple-ref-type-entries=analyze --coloured-sketchline --relaxed-begin-end-for=train,subway,light_rail,monorail,tram"
+ANALYSIS_OPTIONS="--language=fr --check-bus-stop --link-gtfs --show-gtfs --gtfs-feed=$PREFIX --max-error=10 --check-access --check-way-type --check-name-relaxed --check-stop-position --check-sequence --check-version --check-osm-separator --check-platform --check-roundabouts --expect-network-long --multiple-ref-type-entries=analyze --coloured-sketchline --relaxed-begin-end-for=train,subway,light_rail,monorail,tram"
 
 # --check-gtfs
 # --expect-network-short


### PR DESCRIPTION
Remove option --check-motorway-link as several transportation lines do have a highway motorway-link and a highway=service in-between which is not wrong but we do get a warning through PTNA (see example Var 2601 and Var 2801).