### PR TITLE
Remove TER from NETWORK_LONG

### DIFF
--- a/UTC+01/FR/PAC/FR-PAC-Hautes-Alpes/settings.sh
+++ b/UTC+01/FR/PAC/FR-PAC-Hautes-Alpes/settings.sh
@@ -12,7 +12,7 @@ PTNA_TIMEZONE="Europe/Paris"
 # OVERPASS_REUSE_ID="FR-PAC-Q3125-train-bus"
 
 OVERPASS_QUERY="https://overpass-api.de/api/interpreter?data=[timeout:300];area[wikidata~'^(Q3125|Q871282|Q1018595)$'][type=boundary];(rel(area)[~'route'~'(train|tram|bus)'];rel(br);rel[type='route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r);node(w);way(r.routes);node(w);node(r.routes););out;"
-NETWORK_LONG="TER Provence-Alpes-Côte d'Azur|L'Agglo en bus|TUB Briançon"
+NETWORK_LONG="L'Agglo en bus|TUB Briançon"
 NETWORK_SHORT=""
 
 ANALYSIS_PAGE="Hautes-Alpes/Transports_en_commun/Analyse"


### PR DESCRIPTION
Remove TER from NETWORK_LONG as it is listed into the Zou ! network page.