### PR TITLE
Remove train routes

### DIFF
--- a/UTC+01/FR/PAC/FR-PAC-Orizo/settings.sh
+++ b/UTC+01/FR/PAC/FR-PAC-Orizo/settings.sh
@@ -9,10 +9,10 @@ PREFIX="FR-PAC-Orizo"
 PTNA_TIMEZONE="Europe/Paris"
 
 # avoid downloading same area/data if the data has already been downloaded and is not older than 1 hour (start analysis with: "ptna-networks.sh -fo" to 'f'orce download via 'o'verpass api)
-# OVERPASS_REUSE_ID="FR-PAC-Q1120105-train-tram-bus"
+# OVERPASS_REUSE_ID="FR-PAC-Q1120105-tram-bus"
 
 # Use the Wikidata boundary of the Grand Avignon to get the Orizo bus lines near Villeneuve-lès-Avignon
-OVERPASS_QUERY="https://overpass-api.de/api/interpreter?data=[timeout:300];area[wikidata=Q1120105][type=boundary];(rel(area)[~'route'~'(train|tram|bus)'];rel(br);rel[type='route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r);node(w);way(r.routes);node(w);node(r.routes););out;"
+OVERPASS_QUERY="https://overpass-api.de/api/interpreter?data=[timeout:300];area[wikidata=Q1120105][type=boundary];(rel(area)[~'route'~'(tram|bus)'];rel(br);rel[type='route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r);node(w);way(r.routes);node(w);node(r.routes););out;"
 NETWORK_LONG="Orizo"
 NETWORK_SHORT=""
 


### PR DESCRIPTION
Remove train routes as these one are listed into the Zou ! regional transportation page.