### PR TITLE
DE-MV-VVR

### DIFF
--- a/UTC+01/DE/MV/DE-MV-VVR/settings.sh
+++ b/UTC+01/DE/MV/DE-MV-VVR/settings.sh
@@ -50,5 +50,5 @@ PTNA_WWW_DISCUSSION_NAME="Diskussion"
 PTNA_WWW_DISCUSSION_LINK="https://wiki.openstreetmap.org/wiki/$ANALYSIS_TALK"
 
 # Name + Link to list of expected public ransport routes page (usually in OSM Wiki but can als be on GitHub)
-PTNA_WWW_ROUTES_NAME="MVV Linien"
+PTNA_WWW_ROUTES_NAME="VVR Linien"
 PTNA_WWW_ROUTES_LINK="https://wiki.openstreetmap.org/wiki/$WIKI_ROUTES_PAGE"

--- a/UTC+01/DE/MV/DE-MV-VVR/settings.sh
+++ b/UTC+01/DE/MV/DE-MV-VVR/settings.sh
@@ -4,7 +4,7 @@
 # set variables for analysis of network
 #
 
-PREFIX="DE-BY-VVR"
+PREFIX="DE-MV-VVR"
 
 PTNA_TIMEZONE="Europe/Berlin"
 

--- a/UTC+01/DE/MV/DE-MV-VVR/settings.sh
+++ b/UTC+01/DE/MV/DE-MV-VVR/settings.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+#
+# set variables for analysis of network
+#
+
+PREFIX="DE-BY-VVR"
+
+PTNA_TIMEZONE="Europe/Berlin"
+
+OVERPASS_QUERY="http://overpass-api.de/api/interpreter?data=[timeout:600];area[boundary=administrative][admin_level=6][name~'(Vorpommern)'];(rel(area)[~'route'~'(bus|tram|train|subway|light_rail|trolleybus|ferry|monorail|aerialway|share_taxi|funicular)'];rel(br);rel[type='route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r);node(w);way(r.routes);node(w);node(r.routes););out;"
+NETWORK_LONG="Verkehrsgesellschaft Vorpommern-Rügen"
+NETWORK_SHORT="VVR"
+
+ANALYSIS_PAGE="Mecklenburg-Vorpommern/Vorpommern/Transportation/Analyse"
+ANALYSIS_TALK="Talk:Mecklenburg-Vorpommern/Vorpommern/Transportation/Analyse"
+WIKI_ROUTES_PAGE="Mecklenburg-Vorpommern/Vorpommern/Transportation/VVR-Linien-gesamt"
+
+ANALYSIS_OPTIONS="--language=de --check-gtfs --link-gtfs --gtfs-feed=$PREFIX --max-error=10 --check-access --check-way-type --check-service-type --check-name-relaxed --check-stop-position --check-sequence --check-version --check-osm-separator --check-motorway-link --check-route-ref --check-way-type --check-service-type --multiple-ref-type-entries=analyze --coloured-sketchline --expect-network-long --relaxed-begin-end-for=train,subway,light_rail,monorail,tram"
+
+# --show-gtfs
+# --check-bus-stop
+# --positive-notes
+# --expect-network-short
+# --expect-network-short-for=
+# --expect-network-long-for=
+
+#
+# extensions to support ptna-www and PHP in results/xx/index.php files by code in ptna-network.sh (section: upload results)
+#
+# Name + Link to Analysis Result Page on server
+# automatically build by PHP script
+
+# Name + Link to Overpass-Turbo call to show area on map
+PTNA_WWW_REGION_NAME="Region Vorpommern"
+PTNA_WWW_REGION_LINK="http://overpass-turbo.eu/map.html?Q=%5Bout%3Ajson%5D%5Btimeout%3A25%5D%3B(relation%5Bboundary%3Dadministrative%5D%5Badmin_level%3D6%5D%5Bname~%27(Dachau%7CM%C3%BCnchen%7CEbersberg%7CErding%7CStarnberg%7CFreising%7CT%C3%B6lz%7CWolfratshausen%7CF%C3%BCrstenfeldbruck)%27%5D%3B)%3Bout%20body%3B%3E%3Bout%20skel%20qt%3B"
+
+# Name + Link to the network provider / transport association
+PTNA_WWW_NETWORK_NAME="Verkehrsgesellschaft Vorpommern-Rügen"
+PTNA_WWW_NETWORK_LINK="https://www.vvr-bus.de/;"
+
+# Date and Time of last analysis in UTC and Local Time format
+# automatically build by PHP script
+
+# Date and Time of latest changes in UTC and Local Time format
+# automatically build by PHP script
+
+# Name + Link to discussion / documentation page (usually in OSM Wiki)
+PTNA_WWW_DISCUSSION_NAME="Diskussion"
+PTNA_WWW_DISCUSSION_LINK="https://wiki.openstreetmap.org/wiki/$ANALYSIS_TALK"
+
+# Name + Link to list of expected public ransport routes page (usually in OSM Wiki but can als be on GitHub)
+PTNA_WWW_ROUTES_NAME="MVV Linien"
+PTNA_WWW_ROUTES_LINK="https://wiki.openstreetmap.org/wiki/$WIKI_ROUTES_PAGE"

--- a/UTC+01/DE/MV/DE-MV-VVR/settings.sh
+++ b/UTC+01/DE/MV/DE-MV-VVR/settings.sh
@@ -8,7 +8,7 @@ PREFIX="DE-BY-VVR"
 
 PTNA_TIMEZONE="Europe/Berlin"
 
-OVERPASS_QUERY="http://overpass-api.de/api/interpreter?data=[timeout:600];area[boundary=administrative][admin_level=6][name~'(Vorpommern)'];(rel(area)[~'route'~'(bus|tram|train|subway|light_rail|trolleybus|ferry|monorail|aerialway|share_taxi|funicular)'];rel(br);rel[type='route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r);node(w);way(r.routes);node(w);node(r.routes););out;"
+OVERPASS_QUERY="http://overpass-api.de/api/interpreter?data=[timeout:600];area[boundary=administrative][admin_level=6][name~'Vorpommern-Rügen'];(rel(area)[~'route'~'(bus|tram|train|subway|light_rail|trolleybus|ferry|monorail|aerialway|share_taxi|funicular)'];rel(br);rel[type='route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r);node(w);way(r.routes);node(w);node(r.routes););out;"
 NETWORK_LONG="Verkehrsgesellschaft Vorpommern-Rügen"
 NETWORK_SHORT="VVR"
 
@@ -32,8 +32,8 @@ ANALYSIS_OPTIONS="--language=de --check-gtfs --link-gtfs --gtfs-feed=$PREFIX --m
 # automatically build by PHP script
 
 # Name + Link to Overpass-Turbo call to show area on map
-PTNA_WWW_REGION_NAME="Region Vorpommern"
-PTNA_WWW_REGION_LINK="http://overpass-turbo.eu/map.html?Q=%5Bout%3Ajson%5D%5Btimeout%3A25%5D%3B(relation%5Bboundary%3Dadministrative%5D%5Badmin_level%3D6%5D%5Bname~%27(Dachau%7CM%C3%BCnchen%7CEbersberg%7CErding%7CStarnberg%7CFreising%7CT%C3%B6lz%7CWolfratshausen%7CF%C3%BCrstenfeldbruck)%27%5D%3B)%3Bout%20body%3B%3E%3Bout%20skel%20qt%3B"
+PTNA_WWW_REGION_NAME="Region Vorpommern-Rügen"
+PTNA_WWW_REGION_LINK="https://overpass-turbo.eu/map.html?Q=[out%3Ajson][timeout%3A25]%3B(relation[boundary%3Dadministrative][admin_level%3D6][name~%27Vorpommern-R%C3%BCgen%27]%3B)%3Bout%20body%3B%3E%3Bout%20skel%20qt%3B"
 
 # Name + Link to the network provider / transport association
 PTNA_WWW_NETWORK_NAME="Verkehrsgesellschaft Vorpommern-Rügen"


### PR DESCRIPTION
Hi Toni, ich würde gerne den VVR hinzufügen. Dazu habe ich die Münchener settings.sh mal kopiert und angepasst. Es gibt vom VVR keinerlei GTFS Daten - nur PDFs mit Fahrplänen und eine Netzkarte.

- Daher müssten die ANALYSIS_OPTIONS noch sinnvoll angepasst werden. Macht es dann überhaupt noch Sinn den VVR hinzuzufügen?

- Die Wiki Seiten existieren noch nicht

Was wäre der nächste Schritt, um trotzdem eine Auswertung der IST-Daten zu bekommen? Ginge das?