### PR TITLE
addition of CH-KtGR, plus few minor additions/cleanups

### DIFF
--- a/UTC+01/CH/CH-CTGE/settings.sh
+++ b/UTC+01/CH/CH-CTGE/settings.sh
@@ -10,8 +10,8 @@ GTFS_FEED="CH-Alle"
 PTNA_TIMEZONE="Europe/Zurich"
 
 OVERPASS_QUERY="http://overpass-api.de/api/interpreter?data=area[boundary=administrative][wikidata~'^(Q11917)$'];(rel(area)[~'route'~'(bus|tram|train|subway|light_rail|trolleybus|ferry|monorail|aerialway|share_taxi|funicular)'];rel(br);rel[~'type'~'route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r);node(w);way(r.routes);node(w);node(r.routes););out;"
-NETWORK_LONG="Transports Publics Genevois|Communauté tarifaire genevoise|Communauté Tarifaire Genevoise|unireso|Unireso"
-NETWORK_SHORT="CTGE|TPG"
+NETWORK_LONG="Communauté tarifaire genevoise|Communauté Tarifaire Genevoise|unireso|Unireso"
+NETWORK_SHORT="CTGE"
 
 ANALYSIS_PAGE="Switzerland:Public_Transport/Unireso/Analysis"
 ANALYSIS_TALK="Talk:Switzerland:Public_Transport/Unireso/Analysis"

--- a/UTC+01/CH/CH-CTM/settings.sh
+++ b/UTC+01/CH/CH-CTM/settings.sh
@@ -10,8 +10,8 @@ GTFS_FEED="CH-Alle"
 PTNA_TIMEZONE="Europe/Zurich"
 
 OVERPASS_QUERY="http://overpass-api.de/api/interpreter?data=area[boundary=administrative][wikidata~'^(Q12724|Q23013974)$'];(rel(area)[~'route'~'(bus|tram|train|subway|light_rail|trolleybus|ferry|monorail|aerialway|share_taxi|funicular)'];rel(br);rel[~'type'~'route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r);node(w);way(r.routes);node(w);node(r.routes););out;"
-NETWORK_LONG="Comunità tariffale Arcobaleno|Arcobaleno|arcobaleno"
-NETWORK_SHORT="CTM"
+NETWORK_LONG="Comunità tariffale Ticino e Moesano|Comunità tariffale Arcobaleno|Tariffa Integrata Arcobaleno|Arcobaleno|arcobaleno"
+NETWORK_SHORT="CTM|TIA"
 
 ANALYSIS_PAGE="Switzerland:Public_Transport/Arcobaleno/Analysis"
 ANALYSIS_TALK="Talk:Switzerland:Public_Transport/Arcobaleno/Analysis"
@@ -36,7 +36,7 @@ PTNA_WWW_REGION_NAME="Cantone Ticino (TI) e Distretto di Moësa (GR)"
 PTNA_WWW_REGION_LINK="http://overpass-turbo.eu/map.html?Q=%5Bout%3Ajson%5D%5Btimeout%3A25%5D%3B(relation%5Bboundary%3Dadministrative%5D%5Bwikidata~%22^(Q12724|Q23013974)$%22%5D%3B)%3Bout%20body%3B%3E%3Bout%20skel%20qt%3B"
 
 # Name + Link to the network provider / transport association
-PTNA_WWW_NETWORK_NAME="Comunità Tariffale Arcobaleno «Arcobaleno»"
+PTNA_WWW_NETWORK_NAME="Comunità tariffale Ticino e Moesano «Arcobaleno»"
 PTNA_WWW_NETWORK_LINK="https://www.arcobaleno.ch/"
 
 # Date and Time of last analysis in UTC and Local Time format

--- a/UTC+01/CH/CH-CTNE/settings.sh
+++ b/UTC+01/CH/CH-CTNE/settings.sh
@@ -11,7 +11,7 @@ PTNA_TIMEZONE="Europe/Zurich"
 
 OVERPASS_QUERY="http://overpass-api.de/api/interpreter?data=area[boundary=administrative][wikidata~'^(Q12738)$'];(rel(area)[~'route'~'(bus|tram|train|subway|light_rail|trolleybus|ferry|monorail|aerialway|share_taxi|funicular)'];rel(br);rel[~'type'~'route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r);node(w);way(r.routes);node(w);node(r.routes););out;"
 NETWORK_LONG="Communauté tarifaire neuchâteloise|Communauté Tarifaire Neuchâteloise|Onde Verte"
-NETWORK_SHORT="CTNE|TransN|transN|TRN"
+NETWORK_SHORT="CTNE"
 
 ANALYSIS_PAGE="Switzerland:Public_Transport/TransN/Analysis"
 ANALYSIS_TALK="Talk:Switzerland:Public_Transport/TransN/Analysis"

--- a/UTC+01/CH/CH-CtVS/settings.sh
+++ b/UTC+01/CH/CH-CtVS/settings.sh
@@ -11,7 +11,7 @@ PTNA_TIMEZONE="Europe/Zurich"
 
 OVERPASS_QUERY="http://overpass-api.de/api/interpreter?data=area[boundary=administrative][wikidata~'^(Q834)$'];(rel(area)[~'route'~'(bus|tram|train|subway|light_rail|trolleybus|ferry|monorail|aerialway|share_taxi|funicular)'];rel(br);rel[~'type'~'route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r);node(w);way(r.routes);node(w);node(r.routes););out;"
 NETWORK_LONG=""
-NETWORK_SHORT=""
+NETWORK_SHORT="CH-VS"
 
 ANALYSIS_PAGE="Switzerland:Public_Transport/Canton_de_Valais/Analysis"
 ANALYSIS_TALK="Talk:Switzerland:Public_Transport/Canton_de_Valais/Analysis"
@@ -32,11 +32,11 @@ ANALYSIS_OPTIONS="--language=fr --check-gtfs --link-gtfs --show-gtfs --gtfs-feed
 # automatically build by PHP script
 
 # Name + Link to Overpass-Turbo call to show area on map
-PTNA_WWW_REGION_NAME="Canton de Valais (VS)"
+PTNA_WWW_REGION_NAME="Canton de Valais/Kanton Wallis (VS)"
 PTNA_WWW_REGION_LINK="http://overpass-turbo.eu/map.html?Q=%5Bout%3Ajson%5D%5Btimeout%3A25%5D%3B(relation%5Bboundary%3Dadministrative%5D%5Bwikidata~%22^(Q834)$%22%5D%3B)%3Bout%20body%3B%3E%3Bout%20skel%20qt%3B"
 
 # Name + Link to the network provider / transport association
-PTNA_WWW_NETWORK_NAME="Canton de Valais - divers"
+PTNA_WWW_NETWORK_NAME="Canton de Valais/Kanton Wallis - divers/diverse"
 PTNA_WWW_NETWORK_LINK=""
 
 # Date and Time of last analysis in UTC and Local Time format

--- a/UTC+01/CH/CH-KtGR/settings.sh
+++ b/UTC+01/CH/CH-KtGR/settings.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+#
+# set variables for analysis of network
+#
+
+PREFIX="CH-KtGR"
+GTFS_FEED="CH-Alle"
+
+PTNA_TIMEZONE="Europe/Zurich"
+
+OVERPASS_QUERY="http://overpass-api.de/api/interpreter?data=area[boundary=administrative][wikidata~'^(Q21916797|Q23013963|Q23013965|Q23013977|Q23013948|Q23732284|Q23013973|Q23013976|Q23013972|Q22918253)$'];(rel(area)[~'route'~'(bus|tram|train|subway|light_rail|trolleybus|ferry|monorail|aerialway|share_taxi|funicular)'];rel(br);rel[~'type'~'route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r);node(w);way(r.routes);node(w);node(r.routes););out;"
+NETWORK_LONG=""
+NETWORK_SHORT="CH-GR"
+
+ANALYSIS_PAGE="Switzerland:Public_Transport/Kanton_Graubünden/Analysis"
+ANALYSIS_TALK="Talk:Switzerland:Public_Transport/Kanton_Graubünden/Analysis"
+WIKI_ROUTES_PAGE="Switzerland:Public_Transport/Kanton_Graubünden/Analysis/CH-KtGR-Routes"
+
+ANALYSIS_OPTIONS="--language=de --check-gtfs --link-gtfs --show-gtfs --gtfs-feed=$GTFS_FEED --max-error=10 --check-access --check-way-type --check-service-type --check-name-relaxed --check-stop-position --check-sequence --check-version --check-osm-separator --check-motorway-link --multiple-ref-type-entries=analyze --positive-notes --coloured-sketchline --relaxed-begin-end-for=train,subway,light_rail,monorail,tram"
+
+# --check-bus-stop
+# --expect-network-long
+# --expect-network-short
+# --expect-network-short-for=
+# --expect-network-long-for=
+
+#
+# extensions to support ptna-www and PHP in results/xx/index.php files by code in ptna-network.sh (section: upload results)
+#
+# Name + Link to Analysis Result Page on server
+# automatically build by PHP script
+
+# Name + Link to Overpass-Turbo call to show area on map
+PTNA_WWW_REGION_NAME="Kanton Graubünden (GR) ohne Misox"
+PTNA_WWW_REGION_LINK="http://overpass-turbo.eu/map.html?Q=%5Bout%3Ajson%5D%5Btimeout%3A25%5D%3B(relation%5Bboundary%3Dadministrative%5D%5Bwikidata~%22^(Q21916797|Q23013963|Q23013965|Q23013977|Q23013948|Q23732284|Q23013973|Q23013976|Q23013972|Q22918253)$%22%5D%3B)%3Bout%20body%3B%3E%3Bout%20skel%20qt%3B"
+
+# Name + Link to the network provider / transport association
+PTNA_WWW_NETWORK_NAME="Kanton Graubünden ohne Misox - diverse"
+PTNA_WWW_NETWORK_LINK=""
+
+# Date and Time of last analysis in UTC and Local Time format
+# automatically build by PHP script
+
+# Date and Time of latest changes in UTC and Local Time format
+# automatically build by PHP script
+
+# Name + Link to discussion / documentation page (usually in OSM Wiki)
+PTNA_WWW_DISCUSSION_NAME="Discussion"
+PTNA_WWW_DISCUSSION_LINK="https://wiki.openstreetmap.org/wiki/$ANALYSIS_TALK"
+
+# Name + Link to list of expected public ransport routes page (usually in OSM Wiki but can als be on GitHub)
+PTNA_WWW_ROUTES_NAME="Kanton Uri Lines"
+PTNA_WWW_ROUTES_LINK="https://wiki.openstreetmap.org/wiki/$WIKI_ROUTES_PAGE"

--- a/UTC+01/CH/CH-KtUR/settings.sh
+++ b/UTC+01/CH/CH-KtUR/settings.sh
@@ -11,7 +11,7 @@ PTNA_TIMEZONE="Europe/Zurich"
 
 OVERPASS_QUERY="http://overpass-api.de/api/interpreter?data=area[boundary=administrative][wikidata~'^(Q12404)$'];(rel(area)[~'route'~'(bus|tram|train|subway|light_rail|trolleybus|ferry|monorail|aerialway|share_taxi|funicular)'];rel(br);rel[~'type'~'route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r);node(w);way(r.routes);node(w);node(r.routes););out;"
 NETWORK_LONG=""
-NETWORK_SHORT=""
+NETWORK_SHORT="CH-UR"
 
 ANALYSIS_PAGE="Switzerland:Public_Transport/Kanton_Uri/Analysis"
 ANALYSIS_TALK="Talk:Switzerland:Public_Transport/Kanton_Uri/Analysis"

--- a/UTC+01/CH/CH-Vagabond/settings.sh
+++ b/UTC+01/CH/CH-Vagabond/settings.sh
@@ -10,8 +10,8 @@ GTFS_FEED="CH-Alle"
 PTNA_TIMEZONE="Europe/Zurich"
 
 OVERPASS_QUERY="http://overpass-api.de/api/interpreter?data=area[boundary=administrative][wikidata~'^(Q12755)$'];(rel(area)[~'route'~'(bus|tram|train|subway|light_rail|trolleybus|ferry|monorail|aerialway|share_taxi|funicular)'];rel(br);rel[~'type'~'route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r);node(w);way(r.routes);node(w);node(r.routes););out;"
-NETWORK_LONG="Vagabond"
-NETWORK_SHORT=""
+NETWORK_LONG="Communauté tarifaire jurassienne|Communauté Tarifaire Jurassienne|Vagabond"
+NETWORK_SHORT="CTJU"
 
 ANALYSIS_PAGE="Switzerland:Public_Transport/VagABOnd/Analysis"
 ANALYSIS_TALK="Talk:Switzerland:Public_Transport/VagABOnd/Analysis"
@@ -36,7 +36,7 @@ PTNA_WWW_REGION_NAME="Canton de Jura (JU)"
 PTNA_WWW_REGION_LINK="http://overpass-turbo.eu/map.html?Q=%5Bout%3Ajson%5D%5Btimeout%3A25%5D%3B(relation%5Bboundary%3Dadministrative%5D%5Bwikidata~%22^(Q12755)$%22%5D%3B)%3Bout%20body%3B%3E%3Bout%20skel%20qt%3B"
 
 # Name + Link to the network provider / transport association
-PTNA_WWW_NETWORK_NAME="Vagabond"
+PTNA_WWW_NETWORK_NAME="Communauté tarifaire jurassienne «Vagabond»"
 PTNA_WWW_NETWORK_LINK="https://www.levagabond.ch/"
 
 # Date and Time of last analysis in UTC and Local Time format


### PR DESCRIPTION
Hi, while updating public transport entries for Switzerland with GTFS 2023 data, I found an entry for Graubünden that never got integrated, so I figured I'll add it, including pseudo-networks for UR (already in use, but not implemented so it's mixed up with Flixbus) and VS.

I also updated the network strings for Arcobaleno and Vagabond (now officially CTJU according to DiDok), and removed operators from the network strings on Unireso (GE) and Onde Verte (NE).

HTH