### PR TITLE
Add new network

### DIFF
--- a/UTC+01/FR/ARA/FR-ARA-Drôme/settings.sh
+++ b/UTC+01/FR/ARA/FR-ARA-Drôme/settings.sh
@@ -10,7 +10,7 @@ PTNA_TIMEZONE="Europe/Paris"
 
 # Use the Wikidata boundary of the departement Drome plus the small boundary Guilherand-Granges to get all bus lines
 OVERPASS_QUERY="https://overpass-api.de/api/interpreter?data=[timeout:600];area[wikidata~'^(Q3364|Q274292)$'][type=boundary];(rel(area)[~'route'~'(tram|bus)'];rel(br);rel[~'type'~'route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r);node(w);way(r.routes);node(w);node(r.routes););out;"
-NETWORK_LONG="Montélibus|Citéa|Nyons Bus|Cars Région Drôme"
+NETWORK_LONG="Montélibus|Citéa|Nyons Bus|Cars Région Drôme|Cars Région Express"
 NETWORK_SHORT=""
 
 ANALYSIS_PAGE="Drôme/Transports_en_commun/Analyse"


### PR DESCRIPTION
Add new network Cars Région Express due to splitting of the existing region network into several networks.