### PR TITLE
Add CTS network for Eurométropole de Strasbourg

### DIFF
--- a/UTC+01/FR/GE/FR-GE-CTS
+++ b/UTC+01/FR/GE/FR-GE-CTS
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+#
+# set variables for analysis of network
+#
+
+PREFIX="FR-GE-CTS"
+
+PTNA_TIMEZONE="Europe/Paris"
+
+# avoid downloading same area/data if the data has already been downloaded and is not older than 1 hour (start analysis with: "ptna-networks.sh -fo" to 'f'orce download)
+OVERPASS_REUSE_ID="FR-GE-CTS"
+
+# Use the Wikidata boundary of the Eurométropole de Strasbourg
+OVERPASS_QUERY="https://overpass-api.de/api/interpreter?data=[timeout:600];area[wikidata~'^(Q586704)$'][type=boundary];(rel(area)[~'route'~'(tram|bus)'];rel(br);rel[~'type'~'route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r);node(w);way(r.routes);node(w);node(r.routes););out;"
+NETWORK_LONG="Compagnie des Transports Strasbourgeois"
+NETWORK_SHORT="CTS"
+
+ANALYSIS_PAGE="Strasbourg/CTS/Analyse"
+ANALYSIS_TALK="Talk:Strasbourg/CTS/Analyse"
+WIKI_ROUTES_PAGE="Strasbourg/CTS/PTNA"
+
+ANALYSIS_OPTIONS="--language=fr --check-bus-stop --link-gtfs --show-gtfs --gtfs-feed=$PREFIX --max-error=10 --check-access --check-way-type --check-service-type --check-name-relaxed --check-stop-position --check-sequence --check-version --check-osm-separator --check-motorway-link --check-platform --check-roundabouts --expect-network-long --multiple-ref-type-entries=analyze --coloured-sketchline --relaxed-begin-end-for=train,subway,light_rail,monorail,tram"
+
+# --check-gtfs
+# --expect-network-short
+# --expect-network-short-for=
+# --expect-network-long-for=
+# --positive-notes
+
+#
+# extensions to support ptna-www and PHP in results/xx/index.php files by code in ptna-network.sh (section: upload results)
+#
+# Name + Link to Analysis Result Page on server
+# automatically build by PHP script
+
+# Name + Link to Overpass-Turbo call to show area on map
+PTNA_WWW_REGION_NAME="Eurométropole de Strasbourg"
+PTNA_WWW_REGION_LINK="https://overpass-turbo.eu/map.html?Q=[out%3Ajson][timeout%3A25]%3B(relation[wikidata~%27^(Q586704)%24%27][type%3Dboundary]%3B)%3Bout+body%3B%3E%3Bout+skel+qt%3B{{data%3Aoverpass%2Cserver%3D%2F%2Foverpass.openstreetmap.fr%2Fapi%2F}}"
+
+# Name + Link to the network provider / transport association
+PTNA_WWW_NETWORK_NAME="Compagnie des Transports Strasbourgeois"
+PTNA_WWW_NETWORK_LINK="https://cts-strasbourg.eu/"
+
+# Date and Time of last analysis in UTC and Local Time format
+# automatically build by PHP script
+
+# Date and Time of latest changes in UTC and Local Time format
+# automatically build by PHP script
+
+# Name + Link to discussion / documentation page (usually in OSM Wiki)
+PTNA_WWW_DISCUSSION_NAME="Discussion"
+PTNA_WWW_DISCUSSION_LINK="https://wiki.openstreetmap.org/wiki/$ANALYSIS_TALK"
+
+# Name + Link to list of expected public ransport routes page (usually in OSM Wiki but can als be on GitHub)
+PTNA_WWW_ROUTES_NAME="Lignes CTS"
+PTNA_WWW_ROUTES_LINK="https://wiki.openstreetmap.org/wiki/$WIKI_ROUTES_PAGE"


### PR DESCRIPTION
The "Compagnie des Transports Strasbourgeois" (CTS) is the local transport network of the metropol of Strasbourg (France).
This PR registers the network.

A similar PR was created to register the associated GTFS feed.

I am currently working on the project to map the network, fix what is currently broken, and add GTFS tags.