### PR TITLE
Remove --check-stop-position and --check-roundabouts for Winnipeg

### DIFF
--- a/UTC-06/CA/MB/CA-MB-WT/settings.sh
+++ b/UTC-06/CA/MB/CA-MB-WT/settings.sh
@@ -16,7 +16,7 @@ ANALYSIS_PAGE="Winnipeg/Public_Transport/Analysis"
 ANALYSIS_TALK="Talk:Winnipeg/Public_Transport/Analysis"
 WIKI_ROUTES_PAGE="Winnipeg/Public_Transport/Analysis/WT-Routes"
 
-ANALYSIS_OPTIONS="--check-gtfs --link-gtfs --show-gtfs --gtfs-feed=$PREFIX --allow-coach --check-access --check-way-type --check-service-type --check-name-relaxed --check-stop-position --check-sequence --check-version --check-osm-separator --check-motorway-link --max-error=20 --multiple-ref-type-entries=analyze --positive-notes --coloured-sketchline --check-bus-stop --check-roundabouts"
+ANALYSIS_OPTIONS="--check-gtfs --link-gtfs --show-gtfs --gtfs-feed=$PREFIX --allow-coach --check-access --check-way-type --check-service-type --check-name-relaxed --check-sequence --check-version --check-osm-separator --check-motorway-link --max-error=20 --multiple-ref-type-entries=analyze --positive-notes --coloured-sketchline --check-bus-stop"
 
 # --check-platform
 # --expect-network-long


### PR DESCRIPTION
PTNA prints two error messages in its analysis of Winnipeg Transit that I don't think are relevant:

1. PTv2 route: there is no 'public_transport' = 'stop_position'

Since Winnipeg Transit is just buses, the stop position is equivalent to the location of the pole, marked as public_transport=platform. We should disable the PTNA check.

2. PTv2 route: includes 1 entire roundabout but uses only segments

I think that we can remove this one, but I'm happy to be convinced otherwise by an expert. I see on the OSM Wiki that either including an entire roundabout or including segments is acceptable. The renderer will solve it.

I like having the roundabout be a complete way. In my experience, it has been easier to edit existing roundabouts when they are in a single way. But if there's a good reason why it should be split apart, I'm happy to hear it.