### PR TITLE
Update network name

### DIFF
--- a/UTC+01/FR/PAC/FR-PAC-Hautes-Alpes/settings.sh
+++ b/UTC+01/FR/PAC/FR-PAC-Hautes-Alpes/settings.sh
@@ -12,7 +12,7 @@ PTNA_TIMEZONE="Europe/Paris"
 # OVERPASS_REUSE_ID="FR-PAC-Q3125-train-bus"
 
 OVERPASS_QUERY="https://overpass-api.de/api/interpreter?data=[timeout:600];area[wikidata~'^(Q3125|Q871282|Q1018595)$'][type=boundary];(rel(area)[~'route'~'(tram|bus)'];rel(br);rel[~'type'~'route'](r);)->.routes;(.routes;<<;rel(r.routes);way(r);node(w);way(r.routes);node(w);node(r.routes););out;"
-NETWORK_LONG="L'Agglo en bus|AltiGo|Navettes Villages 05|Navettes Queyras|Navettes Serre-Ponçon|Pays des Écrins"
+NETWORK_LONG="L'Agglo en bus|AltiGo|Navettes Villages 05|Navettes Queyras|VAÏ|Pays des Écrins"
 NETWORK_SHORT=""
 
 ANALYSIS_PAGE="Hautes-Alpes/Transports_en_commun/Analyse"
@@ -38,7 +38,7 @@ PTNA_WWW_REGION_NAME="Hautes-Alpes, Claret (04) et Curbans (04)"
 PTNA_WWW_REGION_LINK="https://overpass-turbo.eu/map.html?Q=[out%3Ajson][timeout%3A25]%3B(relation[wikidata~%27^(Q3125|Q871282|Q1018595)%24%27][type%3Dboundary]%3B)%3Bout+body%3B%3E%3Bout+skel+qt%3B"
 
 # Name + Link to the network provider / transport association
-PTNA_WWW_NETWORK_NAME="L'Agglo en bus;Altigo;Navettes du Queyras;Navettes Serre-Ponçon;Transports du Pays des Écrins"
+PTNA_WWW_NETWORK_NAME="L'Agglo en bus;Altigo;Navettes du Queyras;VAÏ Mobilité Serre-Ponçon;Transports du Pays des Écrins"
 PTNA_WWW_NETWORK_LINK="https://www.gap-tallard-durance.fr/fr/lagglo-au-quotidien/transports-lagglo-en-bus/reseau-lagglo-en-bus/;https://www.monaltigo.fr;https://www.queyras-montagne.com/navettes-transports.html;https://www.ccserreponcon.com/infos-pratiques/transports-collectifs;https://www.paysdesecrins.com/infos-pratiques-hiver/acces-et-transports/sur-place"
 
 # Date and Time of last analysis in UTC and Local Time format


### PR DESCRIPTION
"Navettes Serre-Ponçon" is officially "VAÏ", change network name and link name according to this name change